### PR TITLE
chore: 디스코드 웹훅에 PR 리뷰어 지정 설정 추가

### DIFF
--- a/.github/workflows/pr-to-discord.yml
+++ b/.github/workflows/pr-to-discord.yml
@@ -1,0 +1,78 @@
+name: Notify Reviewers on PR
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+jobs:
+  notify-discord:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get PR reviewers
+        id: reviewers
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          REPO="${{ github.repository }}"
+
+          echo "Fetching reviewers for PR #$PR_NUMBER from $REPO"
+
+          API_RESPONSE=$(gh api repos/$REPO/pulls/$PR_NUMBER 2>err.log || echo "")
+          if [ -s err.log ]; then
+            echo "Error from GitHub API:"
+            cat err.log
+          fi
+
+          if [ -z "$API_RESPONSE" ]; then
+            REVIEWERS="[]"
+          else
+            # 안정적으로 리뷰어 목록 파싱 (null 및 빈 배열 모두 처리)
+            REVIEWERS=$(echo "$API_RESPONSE" | jq -c '[.requested_reviewers?[]?.login] // []')
+          fi
+
+          echo "Reviewers JSON: $REVIEWERS"
+
+          # base64 인코딩하여 GitHub Actions output으로 전달
+          REVIEWERS_B64=$(echo "$REVIEWERS" | base64)
+          echo "reviewers_b64=$REVIEWERS_B64" >> "$GITHUB_OUTPUT"
+
+      - name: Notify Discord
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          USER_MAP: ${{ secrets.USER_MAP }} # 예: {"alice": "1234", "bob": "5678"}
+        run: |
+          set -euo pipefail
+
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_URL="${{ github.event.pull_request.html_url }}"
+
+          # base64 디코딩 후 JSON 배열로 파싱
+          REVIEWERS_JSON=$(echo "${{ steps.reviewers.outputs.reviewers_b64 }}" | base64 --decode)
+          echo "Parsed reviewers: $REVIEWERS_JSON"
+
+          MENTION_LIST=""
+          for user in $(echo "$REVIEWERS_JSON" | jq -r '.[]'); do
+            DISCORD_ID=$(echo "$USER_MAP" | jq -r --arg u "$user" '.[$u] // empty')
+            if [ -n "$DISCORD_ID" ]; then
+              MENTION_LIST="$MENTION_LIST <@$DISCORD_ID>"
+            else
+              MENTION_LIST="$MENTION_LIST @$user"
+            fi
+          done
+
+          if [ -z "$MENTION_LIST" ]; then
+            MENTION_LIST="(리뷰어가 지정되지 않았습니다)"
+          fi
+
+          curl -X POST "$DISCORD_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d @- <<EOF
+          {
+            "content": "${MENTION_LIST}\n새로운 Pull Request: **${PR_TITLE}**\n${PR_URL}"
+          }
+          EOF


### PR DESCRIPTION
## 📝 요약
- PR 리뷰어 지정 시, 디스코드 웹훅 알림에 리뷰어 정보가 함께 표시되도록 설정을 추가했습니다.

## 📝 변경사항
- 디스코드 웹훅 메시지에 리뷰어 지정 정보 추가
- 리뷰어 지정 이벤트 발생 시 알림 트리거 처리 로직 작성

## 📝 추가설명
- 리뷰어 지정자는 PR 알림과 함께 디스코드에서 바로 확인할 수 있습니다.

## 🔗관련 이슈
- #14 

## ✅ PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).