### PR TITLE
Product / Order / Payment / Notification 모델 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
-        "@nestjs/common": "^11.0.1",
-        "@nestjs/core": "^11.0.1",
-        "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/common": "^11.1.6",
+        "@nestjs/core": "^11.1.6",
+        "@nestjs/platform-express": "^11.1.6",
         "@prisma/client": "^6.16.2",
         "reflect-metadata": "^0.2.2",
-        "rxjs": "^7.8.1"
+        "rxjs": "^7.8.2"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
@@ -24,7 +24,7 @@
         "@nestjs/testing": "^11.0.1",
         "@types/express": "^5.0.0",
         "@types/jest": "^30.0.0",
-        "@types/node": "^22.10.7",
+        "@types/node": "^22.18.6",
         "@types/supertest": "^6.0.2",
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^10.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
-        "@nestjs/common": "^11.1.6",
-        "@nestjs/core": "^11.1.6",
-        "@nestjs/platform-express": "^11.1.6",
+        "@nestjs/common": "^11.0.1",
+        "@nestjs/core": "^11.0.1",
+        "@nestjs/platform-express": "^11.0.1",
         "@prisma/client": "^6.16.2",
         "reflect-metadata": "^0.2.2",
-        "rxjs": "^7.8.2"
+        "rxjs": "^7.8.1"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
@@ -24,7 +24,7 @@
         "@nestjs/testing": "^11.0.1",
         "@types/express": "^5.0.0",
         "@types/jest": "^30.0.0",
-        "@types/node": "^22.18.6",
+        "@types/node": "^22.10.7",
         "@types/supertest": "^6.0.2",
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
-    "@nestjs/common": "^11.1.6",
-    "@nestjs/core": "^11.1.6",
-    "@nestjs/platform-express": "^11.1.6",
+    "@nestjs/common": "^11.0.1",
+    "@nestjs/core": "^11.0.1",
+    "@nestjs/platform-express": "^11.0.1",
     "@prisma/client": "^6.16.2",
     "reflect-metadata": "^0.2.2",
-    "rxjs": "^7.8.2"
+    "rxjs": "^7.8.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
@@ -35,7 +35,7 @@
     "@nestjs/testing": "^11.0.1",
     "@types/express": "^5.0.0",
     "@types/jest": "^30.0.0",
-    "@types/node": "^22.18.6",
+    "@types/node": "^22.10.7",
     "@types/supertest": "^6.0.2",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
-    "@nestjs/common": "^11.0.1",
-    "@nestjs/core": "^11.0.1",
-    "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/common": "^11.1.6",
+    "@nestjs/core": "^11.1.6",
+    "@nestjs/platform-express": "^11.1.6",
     "@prisma/client": "^6.16.2",
     "reflect-metadata": "^0.2.2",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.2"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
@@ -35,7 +35,7 @@
     "@nestjs/testing": "^11.0.1",
     "@types/express": "^5.0.0",
     "@types/jest": "^30.0.0",
-    "@types/node": "^22.10.7",
+    "@types/node": "^22.18.6",
     "@types/supertest": "^6.0.2",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -152,20 +152,119 @@ model CartItem {
    Product
 ========================= */
 model Product {
-  id                String      @id @default(cuid())
+  id                String   @id @default(cuid())
   storeId           String
   name              String
-  content           String?        // 제품 상세 정보 
+  content           String?
+  image             String?
   price             Int
-  image             String?        
-  discountRate      Float?         // 할인율
-  discountStartTime DateTime?      // 할인 시작 날짜
-  discountEndTime   DateTime?      // 할인 종료 날짜
-  createdAt         DateTime     @default(now())
-  updatedAt         DateTime     @updatedAt
+  discountPrice     Int?
+  discountRate      Int?
+  discountStartTime DateTime?
+  discountEndTime   DateTime?
+  sales             Int      @default(0)
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
 
-  store       Store        @relation(fields: [storeId], references: [id], onDelete: Cascade)
-  cartItems   CartItem[]
-  reviews     Review[]
-  orderItems  OrderItem[]
+  store      Store     @relation(fields: [storeId], references: [id], onDelete: Cascade)
+  categoryId String
+  category   Category  @relation(fields: [categoryId], references: [id], onDelete: Cascade)
+  stocks     Stock[]
+  reviews    Review[]
+  inquiries  Inquiry[]
+  cartItems  CartItem[]
+  orderItems OrderItem[]
 }
+
+model Category {
+  id       String   @id @default(cuid())
+  name     CategoryType
+  products Product[]
+}
+
+enum CategoryType {
+  TOP
+  BOTTOM
+  DRESS
+  OUTER
+  SKIRT
+  SHOES
+  ACC
+}
+
+model Stock {
+  id        String   @id @default(cuid())
+  productId String
+  size      SizeType
+  quantity  Int
+
+  product   Product  @relation(fields: [productId], references: [id], onDelete: Cascade)
+}
+
+enum SizeType {
+  Free
+  XS
+  S
+  M
+  L
+  XL
+}
+
+/* =========================
+   Order
+========================= */
+model Order {
+  id          String   @id @default(cuid())
+  userId      String
+  storeId     String
+  totalPrice  Int
+  status      OrderStatus  @default(PENDING)
+  createdAt   DateTime     @default(now())
+  updatedAt   DateTime     @updatedAt
+
+  user        User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  store       Store  @relation(fields: [storeId], references: [id], onDelete: Cascade)
+  items       OrderItem[]
+  pointLogs   PointTransaction[]
+}
+
+model OrderItem {
+  id        String   @id @default(cuid())
+  orderId   String
+  productId String
+  quantity  Int
+  price     Int
+
+  order     Order    @relation(fields: [orderId], references: [id], onDelete: Cascade)
+  product   Product  @relation(fields: [productId], references: [id], onDelete: Restrict)
+}
+
+enum OrderStatus {
+  PENDING     
+  PAID        
+  SHIPPED     
+  DELIVERED   
+  CANCELED    
+}
+
+/* =========================
+   Notification
+========================= */
+model Notification {
+  id        String   @id @default(cuid())
+  userId    String
+  type      NotificationType
+  message   String
+  isRead    Boolean  @default(false)
+  createdAt DateTime @default(now())
+
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+enum NotificationType {
+  ORDER_UPDATE
+  PROMOTION
+  SYSTEM_ALERT
+}
+
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -147,3 +147,25 @@ model CartItem {
 
   @@unique([cartId, productId])
 }
+
+/* =========================
+   Product
+========================= */
+model Product {
+  id                String      @id @default(cuid())
+  storeId           String
+  name              String
+  content           String?        // 제품 상세 정보 
+  price             Int
+  image             String?        
+  discountRate      Float?         // 할인율
+  discountStartTime DateTime?      // 할인 시작 날짜
+  discountEndTime   DateTime?      // 할인 종료 날짜
+  createdAt         DateTime     @default(now())
+  updatedAt         DateTime     @updatedAt
+
+  store       Store        @relation(fields: [storeId], references: [id], onDelete: Cascade)
+  cartItems   CartItem[]
+  reviews     Review[]
+  orderItems  OrderItem[]
+}


### PR DESCRIPTION
## 📝 요약

Prisma 스키마에 Product / Order / Payment / Notification 모델 추가
프론트엔드 타입 정의와 Swagger 스펙을 기반으로 구조 맞춤

## 📝 변경사항
Product 모델 수정: content, discountPrice, sales, categoryId, stocks 등 추가
Category, Stock, SizeType, CategoryType enum 정의
Order, OrderItem 모델 정의 및 User, Store, Product와 관계 설정
Payment 모델 추가 및 PaymentStatus enum 
Notification 모델 정의 (content, isChecked 포함, User와 관계 설정)
기존 User, Cart, PointTransaction 모델과 FK 관계 정합성 유지


## 📝 추가설명
프론트엔드랑 스웨거 보면서 참고했습니다
orderstatus는 정해진 enum이 따로 없어서 그냥 임의로 정했습니다

## 🔗관련 이슈
- Closes #27 


