### PR TITLE
fix: [DB] 참조 ID 타입 String 통일 및 불필요한 관계 제거

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,8 +38,7 @@ model User {
   orders        Order[]                        
   reviews       Review[]                       
   inquiries     Inquiry[]          @relation("InquiryAuthor") 
-  answers       Answer[]           @relation("AnswerAuthor")  
-  addresses     Address[]                       
+  answers       Answer[]           @relation("AnswerAuthor")                        
   pointLedger   PointTransaction[] // 포인트 사용/적립 내역              
 
   @@index([role])
@@ -63,7 +62,7 @@ enum GradeLevel {
 
 model Session {
   id           String         @id @default(cuid())
-  userId       Int
+  userId       String
   refreshToken String
   expiresAt    DateTime
   createdAt    DateTime    @default(now())
@@ -77,10 +76,10 @@ model Session {
 /// 포인트 트랜잭션 (사용/적립 기록)
 model PointTransaction {
   id        String            @id @default(cuid())
-  userId    Int
+  userId    String
   delta     Int
   reason    String
-  orderId   Int?
+  orderId   String?
   createdAt DateTime       @default(now())
 
   user      User           @relation(fields: [userId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
## 📝 요약
<!--- ex) 내용 설명 -->

- 참조 ID 타입을 String으로 통일하고, 불필요한 관계 설정을 제거했습니다.

## 📝 변경사항
<!--- ex) 변경사항 -->

- userId, storeId, orderId 등 FK 타입 Int → String으로 수정
- 중복/불필요한 @relation 이름 제거 및 정리

## 📝 추가설명
<!--- ex) 추가설명 -->

- 스키마 일관성 확보 및 유지보수성 개선

## 🔗관련 이슈
- Closes #31 

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).