### PR TITLE
feat : 스토어 상세조회 API 구현

### DIFF
--- a/src/common/pipes/parse-cuid.pipe.ts
+++ b/src/common/pipes/parse-cuid.pipe.ts
@@ -1,0 +1,14 @@
+import { BadRequestException, Injectable, PipeTransform } from '@nestjs/common';
+
+const CUID_REGEX = /^c[0-9a-z]{24}$/;
+
+@Injectable()
+export class ParseCuidPipe implements PipeTransform<string, string> {
+  transform(value: string): string {
+    const v = value?.trim();
+    if (!v || !CUID_REGEX.test(v)) {
+      throw new BadRequestException('유효하지 않은 CUID 형식입니다.');
+    }
+    return v;
+  }
+}

--- a/src/common/pipes/parse-cuid.pipe.ts
+++ b/src/common/pipes/parse-cuid.pipe.ts
@@ -5,10 +5,10 @@ const CUID_REGEX = /^c[0-9a-z]{24}$/;
 @Injectable()
 export class ParseCuidPipe implements PipeTransform<string, string> {
   transform(value: string): string {
-    const v = value?.trim();
-    if (!v || !CUID_REGEX.test(v)) {
+    const trimmedValue = value?.trim();
+    if (!trimmedValue || !CUID_REGEX.test(trimmedValue)) {
       throw new BadRequestException('유효하지 않은 CUID 형식입니다.');
     }
-    return v;
+    return trimmedValue;
   }
 }

--- a/src/store/dto/store-detail.dto.ts
+++ b/src/store/dto/store-detail.dto.ts
@@ -1,0 +1,15 @@
+import { IsDate, IsNotEmpty, IsNumber, IsString } from 'class-validator';
+
+export class StoreDetailDto {
+  @IsString() @IsNotEmpty() id: string;
+  @IsString() @IsNotEmpty() name: string;
+  @IsString() @IsNotEmpty() userId: string;
+  @IsString() @IsNotEmpty() address: string;
+  @IsString() @IsNotEmpty() detailAddress: string;
+  @IsString() @IsNotEmpty() phoneNumber: string;
+  @IsString() @IsNotEmpty() content: string;
+  @IsString() @IsNotEmpty() image?: string;
+  @IsNumber() @IsNotEmpty() favoriteCount: number;
+  @IsDate() @IsNotEmpty() createdAt: Date;
+  @IsDate() @IsNotEmpty() updatedAt: Date;
+}

--- a/src/store/store.controller.ts
+++ b/src/store/store.controller.ts
@@ -12,6 +12,7 @@ import { StoreService } from './store.service';
 import { CreateStoreDto } from './dto/create-store.dto';
 import { StoreDetailDto } from './dto/store-detail.dto';
 import { MockAuthGuard } from '../auth/mock-auth.guard';
+import { ParseCuidPipe } from 'src/common/pipes/parse-cuid.pipe';
 
 @Controller('api/stores')
 export class StoreController {
@@ -26,7 +27,9 @@ export class StoreController {
   }
 
   @Get(':storeId')
-  getStoreDetail(@Param('storeId') storeId: string): Promise<StoreDetailDto> {
+  getStoreDetail(
+    @Param('storeId', ParseCuidPipe) storeId: string,
+  ): Promise<StoreDetailDto> {
     return this.storeService.getStoreDetail(storeId);
   }
 }

--- a/src/store/store.controller.ts
+++ b/src/store/store.controller.ts
@@ -1,7 +1,16 @@
-import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Post,
+  Req,
+  UseGuards,
+  Get,
+  Param,
+} from '@nestjs/common';
 import type { Request } from 'express';
 import { StoreService } from './store.service';
 import { CreateStoreDto } from './dto/create-store.dto';
+import { StoreDetailDto } from './dto/store-detail.dto';
 import { MockAuthGuard } from '../auth/mock-auth.guard';
 
 @Controller('api/stores')
@@ -14,5 +23,10 @@ export class StoreController {
     const user = req.user!;
 
     return this.storeService.create(user.id, user.role, dto);
+  }
+
+  @Get(':storeId')
+  getStoreDetail(@Param('storeId') storeId: string): Promise<StoreDetailDto> {
+    return this.storeService.getStoreDetail(storeId);
   }
 }

--- a/src/store/store.repository.ts
+++ b/src/store/store.repository.ts
@@ -7,8 +7,8 @@ export class StoreRepository {
   constructor(private readonly prisma: PrismaService) {}
 
   async findBySellerId(sellerId: string): Promise<Store | null> {
-    return await this.prisma.store.findFirst({ 
-      where: { sellerId } 
+    return await this.prisma.store.findFirst({
+      where: { sellerId },
     });
   }
 
@@ -17,12 +17,17 @@ export class StoreRepository {
   }
 
   async getBySellerId(sellerId: string): Promise<boolean> {
-    const storeCount = await this.prisma.store.count({ 
-      where: { sellerId } })
-      return storeCount > 0
+    const storeCount = await this.prisma.store.count({
+      where: { sellerId },
+    });
+    return storeCount > 0;
   }
 
   async findById(id: string): Promise<Store | null> {
     return await this.prisma.store.findUnique({ where: { id } });
+  }
+
+  async countFavorites(storeId: string): Promise<number> {
+    return this.prisma.favoriteStore.count({ where: { storeId } });
   }
 }

--- a/src/store/store.service.ts
+++ b/src/store/store.service.ts
@@ -1,10 +1,12 @@
 import {
   ConflictException,
   ForbiddenException,
+  NotFoundException,
   Injectable,
 } from '@nestjs/common';
 import { StoreRepository } from './store.repository';
 import { CreateStoreDto } from './dto/create-store.dto';
+import { StoreDetailDto } from './dto/store-detail.dto';
 import { UserType, Prisma } from '@prisma/client';
 
 @Injectable()
@@ -32,5 +34,27 @@ export class StoreService {
     };
 
     return this.storeRepo.create(data);
+  }
+
+  async getStoreDetail(storeId: string): Promise<StoreDetailDto> {
+    const store = await this.storeRepo.findById(storeId);
+    if (!store) throw new NotFoundException('스토어를 찾을 수 없습니다.');
+
+    const favoriteCount = await this.storeRepo.countFavorites(storeId);
+
+    const result: StoreDetailDto = {
+      id: store.id,
+      name: store.name,
+      createdAt: store.createdAt,
+      updatedAt: store.updatedAt,
+      userId: store.sellerId,
+      address: store.address,
+      detailAddress: store.detailAddress,
+      phoneNumber: store.phoneNumber,
+      content: store.content,
+      image: store.image ?? undefined,
+      favoriteCount,
+    };
+    return result;
   }
 }


### PR DESCRIPTION
## 📝 요약
- 스토어 상세 조회 API를 추가했습니다.

## 📝 변경사항
- CUID 전용 파이프 추가
- StoreController에 ParseCuidPipe 적용으로 storeId 유효성 검증 가능

## 📝 추가설명
- 프로젝트에서 Prisma @default(cuid())를 사용하기 때문에 ID형식이 CUID로 고정되어 있습니다.
- CUID 파이프를 사용하면 컨트롤러 진입 시에 ID형식을 곧바로 검증하여 잘못된 값이 DB에 접근하는 것을 차단할 수 있습니다.
- favoriteCount는 favoriteStore 구조를 기준으로 집계했습니다. 

## 🔗관련 이슈
- Closes #37 

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## ✅ 테스트 결과
<img width="597" height="297" alt="스크린샷 2025-09-22 오후 4 07 35" src="https://github.com/user-attachments/assets/819c80fc-7058-474b-91b5-b64819500b02" />
