### PR TITLE
fix: User-Notification, Store 관계 중복 정의 제거 및 relation name 명시

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,14 +34,14 @@ model User {
   sessions       Session[]
   store          Store?          @relation("StoreOwner")
   favoriteStores FavoriteStore[]
-  notifications  Notification[]
+  notifications  Notification[]  @relation("UserNotifications")
 
-  cart          Cart?                        
-  orders        Order[]                        
-  reviews       Review[]                       
-  inquiries     Inquiry[]          @relation("InquiryAuthor") 
-  answers       Answer[]           @relation("AnswerAuthor")                        
-  pointLedger   PointTransaction[] // 포인트 사용/적립 내역             
+  cart        Cart?
+  orders      Order[]
+  reviews     Review[]
+  inquiries   Inquiry[]          @relation("InquiryAuthor")
+  answers     Answer[]           @relation("AnswerAuthor")
+  pointLedger PointTransaction[] // 포인트 사용/적립 내역             
 
   @@index([type])
 }
@@ -111,8 +111,6 @@ model Store {
   favorites FavoriteStore[]
   Product   Product[]
   Order     Order[]
-  User      User?           @relation(fields: [userId], references: [id])
-  userId    String?
 }
 
 model FavoriteStore {
@@ -136,7 +134,7 @@ model FavoriteStore {
  */
 model Cart {
   id        String   @id @default(cuid())
-  buyerId    String   @unique
+  buyerId   String   @unique
   quantity  Int      @default(0)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -340,5 +338,3 @@ model Answer {
   inquiryId String
   inquiry   Inquiry @relation(fields: [inquiryId], references: [id], onDelete: Cascade)
 }
-
-


### PR DESCRIPTION
## 📝 요약
- User ↔ Notification, Store 관계 정의에서 발생한 모호성 문제를 해결했습니다.

## 📝 변경사항
- User 모델
  - Notification, Store 중복 필드 제거
  - notifications 필드에 relation name(UserNotifications) 명시

- Notification 모델
  - User와의 이중 관계(User 필드) 제거
  - user 필드에 relation name(UserNotifications) 적용

- Store 모델
  - seller 관계만 유지
  - 불필요한 userId/User 필드 제거

## 📝 추가설명
- 동일 모델 간 중복 관계 정의로 인해 Ambiguous relation detected 에러가 발생했습니다.
- relation name을 명시하고 중복된 필드를 제거하여 Prisma가 관계를 명확하게 인식하도록 수정했습니다.
- 스키마 작성 후 `command+s` 를 입력하니 중복되는 관계 필드가 생성되는 것을 발견했습니다. 

## 🔗관련 이슈
- Closes #52 

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).