### PR TITLE
feat: 내 정보 조회/수정 API 구현

### DIFF
--- a/src/users/dto/update-user.dto.ts
+++ b/src/users/dto/update-user.dto.ts
@@ -1,0 +1,19 @@
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class UpdateUserDto {
+  @IsString()
+  @IsOptional()
+  name?: string;
+
+  @IsString()
+  @IsOptional()
+  password?: string;
+
+  @IsString()
+  @IsNotEmpty()
+  currentPassword!: string;
+
+  @IsString()
+  @IsOptional()
+  image?: string;
+}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,16 +1,44 @@
-import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Patch,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UserPayload } from './users.mapper';
+import { AuthGuard } from '@nestjs/passport';
+import { UpdateUserDto } from './dto/update-user.dto';
 
 @Controller('api/users')
 export class UsersController {
-  constructor(private readonly users: UsersService) {}
+  constructor(private readonly usersService: UsersService) {}
 
   // 회원가입: POST /api/users
   @Post()
   @HttpCode(HttpStatus.CREATED)
   async signup(@Body() dto: CreateUserDto): Promise<{ user: UserPayload }> {
-    return await this.users.create(dto);
+    return this.usersService.create(dto);
+  }
+
+  // 내 정보 조회: GET /api/users/me
+  @UseGuards(AuthGuard('jwt'))
+  @Get('me')
+  getMe(@Req() req: any) {
+    return this.usersService.getMe(req.user.userId);
+  }
+
+  // 내 정보 수정 (현재 비밀번호 필수): PATCH /api/users/me
+  @UseGuards(AuthGuard('jwt'))
+  @Patch('me')
+  updateMe(@Req() req: any, @Body() dto: UpdateUserDto) {
+    return this.usersService.updateMe(req.user.userId, dto);
   }
 }

--- a/src/users/users.repository.ts
+++ b/src/users/users.repository.ts
@@ -51,4 +51,8 @@ export class UsersRepository {
   async createUnchecked(data: Prisma.UserUncheckedCreateInput): Promise<User> {
     return this.prisma.user.create({ data });
   }
+
+  async updateById(id: string, data: Prisma.UserUpdateInput): Promise<User> {
+    return this.prisma.user.update({ where: { id }, data });
+  }
 }


### PR DESCRIPTION
## 📝 요약
<!--- ex) 내용 설명 -->
- 내 정보 조회/수정 API 구현. 
   - GET /api/users/me로 본인 정보 반환
   - PATCH /api/users/me에서 currentPassword 검증 후 name/password/image 선택 수정.

## 📝 변경사항
<!--- ex) 변경사항 -->
- UsersController: /me 조회·수정 엔드포인트 추가(AuthGuard('jwt'))
- UsersService: getMe, updateMe 구현(비밀번호 일치 확인 → 선택 필드만 업데이트, 비번은 bcrypt 해시 저장)
- UpdateUserDto: currentPassword 필수, name/password/image 옵션
- UsersRepository: updateById 등 보조 메서드 사용

## 📝 추가설명
<!--- ex) 추가설명 -->
<img width="1493" height="767" alt="스크린샷 2025-09-24 180429" src="https://github.com/user-attachments/assets/7e18415f-87d1-4b5c-b6a1-371f875b62f3" />
<img width="1489" height="767" alt="스크린샷 2025-09-24 192428" src="https://github.com/user-attachments/assets/ccb77056-2520-4783-8627-c8473ba3f01b" />

## 🔗관련 이슈

- Closes #68 

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).