### PR TITLE
refactor: Auth ESLint 타입 오류 수정

### DIFF
--- a/src/auth/auth.types.ts
+++ b/src/auth/auth.types.ts
@@ -1,3 +1,4 @@
+import type { Request as ExpressRequest } from 'express';
 import { UserType } from '@prisma/client';
 
 export type GradeSummary = {
@@ -21,4 +22,19 @@ export type AuthUser = {
   type: UserType;
   points: number;
   grade: GradeSummary;
+};
+
+export type CookieMap = Record<string, string | undefined>;
+export type RequestWithCookies = Omit<ExpressRequest, 'cookies'> & {
+  cookies: CookieMap;
+};
+
+export interface JwtPrincipal {
+  userId: string;
+  email?: string;
+  type?: UserType;
+}
+
+export type RequestWithUser = Omit<ExpressRequest, 'user'> & {
+  user: JwtPrincipal;
 };

--- a/src/auth/cookie.util.ts
+++ b/src/auth/cookie.util.ts
@@ -1,0 +1,26 @@
+import type { Response, CookieOptions } from 'express';
+
+export const REFRESH_COOKIE_NAME = 'refreshToken' as const;
+
+export const getRefreshCookieOptions = (): CookieOptions => {
+  const days = Number(process.env.REFRESH_EXPIRES_DAYS ?? 7);
+
+  const sameSite: CookieOptions['sameSite'] = 'lax';
+  const secure = process.env.NODE_ENV === 'production';
+
+  return {
+    httpOnly: true,
+    sameSite,
+    secure,
+    path: '/',
+    maxAge: days * 24 * 60 * 60 * 1000,
+  };
+};
+
+export const setRefreshCookie = (res: Response, token: string): void => {
+  res.cookie(REFRESH_COOKIE_NAME, token, getRefreshCookieOptions());
+};
+
+export const clearRefreshCookie = (res: Response): void => {
+  res.clearCookie(REFRESH_COOKIE_NAME, getRefreshCookieOptions());
+};


### PR DESCRIPTION
## 📝 요약
<!--- ex) 내용 설명 -->
- ESLint 타입 오류(no-unsafe-member-access/argument/assignment) 제거 및 리프레시 토큰 쿠키 로직 공용 유틸로 분리.

## 📝 변경사항
<!--- ex) 변경사항 -->
- auth.types.ts
   - RequestWithCookies/RequestWithUser를 Omit<ExpressRequest, 'cookies' | 'user'> 기반으로 재정의
   - CookieMap, JwtPrincipal 추가

- cookie.util.ts 신규
   - REFRESH_COOKIE_NAME, getRefreshCookieOptions, setRefreshCookie, clearRefreshCookie 제공

- auth.controller.ts
   - @Req()에 RequestWithCookies | RequestWithUser 적용
   - 쿠키 설정/삭제를 유틸로 위임, 중복 코드 제거
   - 로그인 응답 코드 200으로 정리

## 📝 추가설명
<!--- ex) 추가설명 -->


## 🔗관련 이슈
- Closes #83 

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).