### PR TITLE
feat: 내 관심 스토어 조회 API 구현

### DIFF
--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -1,16 +1,27 @@
-import { IsEmail, IsEnum, IsNotEmpty, MinLength } from 'class-validator';
+import {
+  IsEmail,
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MinLength,
+} from 'class-validator';
 import { UserType } from '@prisma/client';
 
 export class CreateUserDto {
+  @IsString()
   @IsNotEmpty()
   name!: string;
 
+  @IsString()
   @IsEmail()
   email!: string;
 
+  @IsString()
   @MinLength(8)
   password!: string;
 
+  @IsOptional()
   @IsEnum(UserType, { message: 'type must be BUYER or SELLER' })
   type!: UserType; // 'BUYER' | 'SELLER'
 }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-argument */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import {
   Body,
   Controller,
@@ -16,6 +14,7 @@ import { CreateUserDto } from './dto/create-user.dto';
 import { UserPayload } from './users.mapper';
 import { AuthGuard } from '@nestjs/passport';
 import { UpdateUserDto } from './dto/update-user.dto';
+import type { RequestWithUser } from '../auth/auth.types';
 
 @Controller('api/users')
 export class UsersController {
@@ -31,14 +30,24 @@ export class UsersController {
   // 내 정보 조회: GET /api/users/me
   @UseGuards(AuthGuard('jwt'))
   @Get('me')
-  getMe(@Req() req: any) {
+  getMe(@Req() req: RequestWithUser): Promise<UserPayload> {
     return this.usersService.getMe(req.user.userId);
   }
 
   // 내 정보 수정 (현재 비밀번호 필수): PATCH /api/users/me
   @UseGuards(AuthGuard('jwt'))
   @Patch('me')
-  updateMe(@Req() req: any, @Body() dto: UpdateUserDto) {
+  updateMe(
+    @Req() req: RequestWithUser,
+    @Body() dto: UpdateUserDto,
+  ): Promise<UserPayload> {
     return this.usersService.updateMe(req.user.userId, dto);
+  }
+
+  // 내 관심 스토어 조회: GET /api/users/me/likes
+  @UseGuards(AuthGuard('jwt'))
+  @Get('me/likes')
+  getMyLikes(@Req() req: RequestWithUser) {
+    return this.usersService.getMyLikes(req.user.userId);
   }
 }

--- a/src/users/users.repository.ts
+++ b/src/users/users.repository.ts
@@ -55,4 +55,28 @@ export class UsersRepository {
   async updateById(id: string, data: Prisma.UserUpdateInput): Promise<User> {
     return this.prisma.user.update({ where: { id }, data });
   }
+
+  async findLikesByUserId(userId: string) {
+    return this.prisma.favoriteStore.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'desc' }, // 최근 추가순
+      select: {
+        userId: true,
+        storeId: true,
+        store: {
+          select: {
+            id: true,
+            name: true,
+            address: true,
+            detailAddress: true,
+            phoneNumber: true,
+            content: true,
+            image: true,
+            createdAt: true,
+            updatedAt: true,
+          },
+        },
+      },
+    });
+  }
 }

--- a/src/users/users.repository.ts
+++ b/src/users/users.repository.ts
@@ -1,47 +1,27 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import type { Prisma, User } from '@prisma/client';
+import { USER_AUTH_SELECT, FAVORITE_WITH_STORE_SELECT } from './users.select';
 
 export type UserForAuth = Pick<
   User,
   'id' | 'email' | 'nickname' | 'type' | 'gradeLevel' | 'passwordHash'
 >;
 
+// favorite + store select 결과 타입 (정적 타입 안전)
+export type FavoriteWithStoreRow = Prisma.FavoriteStoreGetPayload<{
+  select: typeof FAVORITE_WITH_STORE_SELECT;
+}>;
+
 @Injectable()
 export class UsersRepository {
   constructor(private readonly prisma: PrismaService) {}
 
+  async findById(id: string): Promise<User | null>;
+  async findById(id: string | undefined | null): Promise<User | null>;
   async findById(id: string | undefined | null): Promise<User | null> {
     if (!id) return null;
     return this.prisma.user.findUnique({ where: { id } });
-  }
-
-  // 이메일 중복 확인용
-  async existsByEmail(email: string): Promise<boolean> {
-    const r = await this.prisma.user.findUnique({
-      where: { email },
-      select: { id: true },
-    });
-    return !!r;
-  }
-
-  // 로그인용 (해시 포함)
-  async findByEmailForAuth(email: string): Promise<UserForAuth | null> {
-    return this.prisma.user.findUnique({
-      where: { email },
-      select: {
-        id: true,
-        email: true,
-        nickname: true,
-        type: true,
-        gradeLevel: true,
-        passwordHash: true,
-      },
-    });
-  }
-
-  async findByEmail(email: string): Promise<UserForAuth | null> {
-    return this.findByEmailForAuth(email);
   }
 
   async create(data: Prisma.UserCreateInput): Promise<User> {
@@ -56,27 +36,32 @@ export class UsersRepository {
     return this.prisma.user.update({ where: { id }, data });
   }
 
-  async findLikesByUserId(userId: string) {
+  async exists(where: Prisma.UserWhereInput): Promise<boolean> {
+    const count = await this.prisma.user.count({ where });
+    return count > 0;
+  }
+
+  async existsByEmail(email: string): Promise<boolean> {
+    return this.exists({ email });
+  }
+
+  async findByEmailForAuth(email: string): Promise<UserForAuth | null> {
+    return this.prisma.user.findUnique({
+      where: { email },
+      select: USER_AUTH_SELECT,
+    }) as Promise<UserForAuth | null>;
+  }
+
+  async findByEmail(email: string): Promise<UserForAuth | null> {
+    return this.findByEmailForAuth(email);
+  }
+
+  // 관심 스토어 조회
+  async findLikesByUserId(userId: string): Promise<FavoriteWithStoreRow[]> {
     return this.prisma.favoriteStore.findMany({
       where: { userId },
-      orderBy: { createdAt: 'desc' }, // 최근 추가순
-      select: {
-        userId: true,
-        storeId: true,
-        store: {
-          select: {
-            id: true,
-            name: true,
-            address: true,
-            detailAddress: true,
-            phoneNumber: true,
-            content: true,
-            image: true,
-            createdAt: true,
-            updatedAt: true,
-          },
-        },
-      },
+      orderBy: { createdAt: 'desc' },
+      select: FAVORITE_WITH_STORE_SELECT,
     });
   }
 }

--- a/src/users/users.select.ts
+++ b/src/users/users.select.ts
@@ -1,0 +1,28 @@
+import type { Prisma } from '@prisma/client';
+
+export const USER_AUTH_SELECT: Prisma.UserSelect = {
+  id: true,
+  email: true,
+  nickname: true,
+  type: true,
+  gradeLevel: true,
+  passwordHash: true,
+};
+
+export const STORE_BRIEF_SELECT: Prisma.StoreSelect = {
+  id: true,
+  name: true,
+  address: true,
+  detailAddress: true,
+  phoneNumber: true,
+  content: true,
+  image: true,
+  createdAt: true,
+  updatedAt: true,
+};
+
+export const FAVORITE_WITH_STORE_SELECT: Prisma.FavoriteStoreSelect = {
+  userId: true,
+  storeId: true,
+  store: { select: STORE_BRIEF_SELECT },
+};


### PR DESCRIPTION
## 📝 요약
<!--- ex) 내용 설명 -->
- 리포지토리 코드 정리 및 타입 안전성 강화. 공통 프로젝션(Select) 분리로 중복 제거, 관심스토어 조회 반환 타입 고정.

## 📝 변경사항
<!--- ex) 변경사항 -->
- users.select.ts 추가: 공통 프로젝션 상수(USER_AUTH_SELECT, FAVORITE_WITH_STORE_SELECT) 분리
- users.repository.ts
   - FavoriteWithStoreRow 타입 도입(Prisma GetPayload 기반)
   - exists(where) 헬퍼 추가, existsByEmail 단순화
   - 불필요 코드/중복 Select 제거, 반환 타입 일관화

## 📝 추가설명
<!--- ex) 추가설명 -->
- 프로젝션 상수 변경 시 결과 타입 자동 반영 → 서비스/컨트롤러 오타/누락 컴파일 단계에서 검출
<img width="1486" height="647" alt="스크린샷 2025-09-29 094359" src="https://github.com/user-attachments/assets/f10de9db-3a30-4d62-b510-61134d5419ce" />


## 🔗관련 이슈
- Closes #79 

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).