### PR TITLE
feat: 내 스토어 상품 조회 API 구현

### DIFF
--- a/src/store/dto/store-product-list.dto.ts
+++ b/src/store/dto/store-product-list.dto.ts
@@ -1,0 +1,10 @@
+export class MyStoreProductListItemDto {
+  id!: string;
+  image?: string;
+  name!: string;
+  price!: number;
+  stock!: number;
+  isDiscount!: boolean;
+  createdAt!: string;
+  isSoldOut!: boolean;
+}

--- a/src/store/dto/store-product-query.dto.ts
+++ b/src/store/dto/store-product-query.dto.ts
@@ -1,0 +1,7 @@
+import { Type } from 'class-transformer';
+import { IsInt, Min } from 'class-validator';
+
+export class MyStoreProductQueryDto {
+  @Type(() => Number) @IsInt() @Min(1) page = 1;
+  @Type(() => Number) @IsInt() @Min(1) pageSize = 10;
+}

--- a/src/store/dto/store-product-wrapper.dto.ts
+++ b/src/store/dto/store-product-wrapper.dto.ts
@@ -1,0 +1,14 @@
+import { Type } from 'class-transformer';
+import { IsArray, IsInt, Min, ValidateNested } from 'class-validator';
+import { MyStoreProductListItemDto } from './store-product-list.dto';
+
+export class MyStoreProductListWrapperDto {
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => MyStoreProductListItemDto)
+  list!: MyStoreProductListItemDto[];
+
+  @IsInt()
+  @Min(0)
+  totalCount!: number;
+}

--- a/src/store/store.controller.ts
+++ b/src/store/store.controller.ts
@@ -7,6 +7,7 @@ import {
   Post,
   Req,
   Get,
+  Query,
 } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt.guard';
 import type { AuthUser } from '../auth/auth.types';
@@ -17,6 +18,8 @@ import { StoreDetailDto } from './dto/store-detail.dto';
 import { MyStoreDetailDto } from './dto/mystore-detail.dto';
 import { StoreResponseDto } from './dto/store-response.dto';
 import { ParseCuidPipe } from 'src/common/pipes/parse-cuid.pipe';
+import { MyStoreProductQueryDto } from './dto/store-product-query.dto';
+import { MyStoreProductListWrapperDto } from './dto/store-product-wrapper.dto';
 
 @Controller('api/stores')
 export class StoreController {
@@ -35,6 +38,16 @@ export class StoreController {
   getMyStoreDetail(@Req() req: { user: AuthUser }): Promise<MyStoreDetailDto> {
     const user = req.user;
     return this.storeService.getMyStoreDetail(user.userId, user.type);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('detail/my/product')
+  getMyStoreProducts(
+    @Req() req: { user: AuthUser },
+    @Query() query: MyStoreProductQueryDto,
+  ): Promise<MyStoreProductListWrapperDto> {
+    const { userId, type } = req.user;
+    return this.storeService.getMyStoreProducts(userId, type, query);
   }
 
   @Get(':storeId')


### PR DESCRIPTION
## 📝 요약
- 스토어의 상품을 offset 기반 페이지네이션으로 조회하는 API를 작성했습니다.

## 📝 변경사항
1. DTO
- **MyStoreProductQueryDto** : 쿼리스트링(page, pageSize)을 숫자로 변환(@Type)하고 유효성 검사(@IsInt, @Min(1))하여 페이지네이션 입력으로 사용
- **MyStoreProductListItemDto** : 응답 행(아이템) 전용 모델. stock(상품별 총 재고), isSoldOut, isDiscount, createdAt(UTC ISO) 등 계산/직렬화된 값 포함
- **MyStoreProductListWrapperDto** :  { list, totalCount }로 목록과 전체 개수를 함께 반환

2. Repository 
- **findStoreIdBySellerId**(sellerId) : 판매자ID로 스토어 ID 조회
- **countProductsByStoreId**(storeId) : 페이지네이션 표기를 위한 전체 상품 수 조회
- **findProductPageByStoreId**(storeId, skip, take) : 내림차순 정렬로 현재 페이지 상품목록 조회
- **findStockRowsForProductIds**(productIds) : 전달된 상품들의 사이즈별 재고 row({ productId, quantity }) 조회

3. Service
- 재고 합계 계산(for-of 누적)
   - 현재 스키마에서 재고는 Product가 아니라 사이즈별 Stock 행(row) 으로 분리되어 있어 상품별 총 재고 집계가 필요합니다.
목록 페이지에 필요한 현재 페이지의 productIds만 모아 Stock row들을 한 번에 조회한 뒤, for-of로 명시적으로 합산해 productId → 총 재고 맵을 만들었습니다.
- 내부 헬퍼 사용 이유 (private mapRowToListItem)
   - 서비스의 메서드는 데이터 흐름에만 집중시키고, 필드 단위 계산과 응답은 순수 매퍼 헬퍼로 캡슐화했습니다.
   - private으로 외부 노출을 막아 서비스 API를 깔끔하게 유지할 수 있고, 코드 수정이 필요할 때도 헬퍼만 수정하면 되서 유지보수나 테스트가 간단합니다.

## 📝 추가설명
- 추후 count + findMany를 $transaction으로 변경, 재고 합계 시에 groupBy(_sum) 사용, 캐시 또는 Cursor 기반 페이지네이션으로 수정할 수 있을 것 같습니다. 

## 🔗관련 이슈
- Closes #67 

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## ✅ 테스트 결과
내 스토어에 등록된 상품 조회
<img width="986" height="630" alt="스크린샷 2025-09-29 오후 12 54 12" src="https://github.com/user-attachments/assets/c3d30510-48e9-4f2c-a9fc-54bc6512000f" />
<img width="986" height="764" alt="스크린샷 2025-09-29 오후 12 54 27" src="https://github.com/user-attachments/assets/8281b928-7ca5-448c-abe9-358e76ecf747" />

등록된 상품이 없을 경우 (페이징 흐름 깨지지 않게 404대신 빈 배열 반환)
<img width="989" height="762" alt="스크린샷 2025-09-29 오후 2 32 12" src="https://github.com/user-attachments/assets/027fe3a9-282b-45c5-aede-7629c76a9d28" />
