### PR TITLE
refactor: users.service.ts 매핑 분리

### DIFF
--- a/src/users/users.mapper.ts
+++ b/src/users/users.mapper.ts
@@ -1,4 +1,4 @@
-import { User } from '@prisma/client';
+import type { User } from '@prisma/client';
 import { GRADE_MAP } from '../grades/grade.constants';
 
 export type UserPayload = {
@@ -20,3 +20,57 @@ export const toUserPayload = (u: User): UserPayload => ({
   image: u.image ?? null,
   grade: GRADE_MAP[u.gradeLevel],
 });
+
+export type FavoriteStoreItemDto = {
+  storeId: string;
+  userId: string;
+  store: {
+    id: string;
+    name: string;
+    address: string;
+    detailAddress: string;
+    phoneNumber: string;
+    content: string;
+    image: string | null;
+    createdAt: Date;
+    updatedAt: Date;
+  };
+};
+
+export type FavoriteWithStoreInput = {
+  storeId: string;
+  userId: string;
+  store: {
+    id: string;
+    name: string;
+    address: string;
+    detailAddress: string;
+    phoneNumber: string;
+    content: string;
+    image: string | null;
+    createdAt: Date;
+    updatedAt: Date;
+  };
+};
+
+export const toFavoriteStoreItem = (
+  r: FavoriteWithStoreInput,
+): FavoriteStoreItemDto => ({
+  storeId: r.storeId,
+  userId: r.userId,
+  store: {
+    id: r.store.id,
+    name: r.store.name,
+    address: r.store.address,
+    detailAddress: r.store.detailAddress,
+    phoneNumber: r.store.phoneNumber,
+    content: r.store.content,
+    image: r.store.image ?? null,
+    createdAt: r.store.createdAt,
+    updatedAt: r.store.updatedAt,
+  },
+});
+
+export const toFavoriteStoreList = (
+  rows: FavoriteWithStoreInput[],
+): FavoriteStoreItemDto[] => rows.map(toFavoriteStoreItem);

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -10,6 +10,7 @@ import type { Prisma, User, UserType } from '@prisma/client';
 import { toUserPayload, UserPayload } from './users.mapper';
 import * as bcrypt from 'bcrypt';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { toFavoriteStoreList, FavoriteStoreItemDto } from './users.mapper';
 
 @Injectable()
 export class UsersService {
@@ -67,23 +68,8 @@ export class UsersService {
     const updated = await this.usersRepo.updateById(userId, data);
     return toUserPayload(updated);
   }
-  async getMyLikes(userId: string) {
+  async getMyLikes(userId: string): Promise<FavoriteStoreItemDto[]> {
     const rows = await this.usersRepo.findLikesByUserId(userId);
-    // 스키마 필드명 그대로 반환 (detailAddress, phoneNumber)
-    return rows.map((r) => ({
-      storeId: r.storeId,
-      userId: r.userId,
-      store: {
-        id: r.store.id,
-        name: r.store.name,
-        address: r.store.address,
-        detailAddress: r.store.detailAddress,
-        phoneNumber: r.store.phoneNumber,
-        content: r.store.content,
-        image: r.store.image ?? null,
-        createdAt: r.store.createdAt,
-        updatedAt: r.store.updatedAt,
-      },
-    }));
+    return toFavoriteStoreList(rows);
   }
 }


### PR DESCRIPTION
## 📝 요약
<!--- ex) 내용 설명 -->
- users.service.ts의 관심 스토어 응답 매핑을 users.mapper.ts로 분리하여 가독성과 일관성 개선.

## 📝 변경사항
<!--- ex) 변경사항 -->
- users.service.ts: getMyLikes에서 inline 매핑 제거 → toFavoriteStoreList 호출로 단순화
- users.mapper.ts: FavoriteStoreItemDto, toFavoriteStoreItem, toFavoriteStoreList 추가
- 불필요 주석/임포트 정리

## 📝 추가설명
<!--- ex) 추가설명 -->


## 🔗관련 이슈
- Closes #96 

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).