### PR TITLE
feat: 회원 탈퇴 API 기능 구현

### DIFF
--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   HttpCode,
   HttpStatus,
@@ -49,5 +50,13 @@ export class UsersController {
   @Get('me/likes')
   getMyLikes(@Req() req: RequestWithUser) {
     return this.usersService.getMyLikes(req.user.userId);
+  }
+  // 회원 탈퇴: DELETE /api/users/delete
+  @UseGuards(AuthGuard('jwt'))
+  @Delete('delete')
+  @HttpCode(HttpStatus.OK)
+  async deleteMe(@Req() req: RequestWithUser) {
+    await this.usersService.deleteMe(req.user.userId);
+    return { message: '회원 탈퇴가 완료되었습니다.' };
   }
 }

--- a/src/users/users.repository.ts
+++ b/src/users/users.repository.ts
@@ -64,4 +64,8 @@ export class UsersRepository {
       select: FAVORITE_WITH_STORE_SELECT,
     });
   }
+
+  async deleteById(id: string): Promise<void> {
+    await this.prisma.user.delete({ where: { id } });
+  }
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -72,4 +72,9 @@ export class UsersService {
     const rows = await this.usersRepo.findLikesByUserId(userId);
     return toFavoriteStoreList(rows);
   }
+  async deleteMe(userId: string): Promise<void> {
+    const user = await this.usersRepo.findById(userId);
+    if (!user) throw new NotFoundException('유저를 찾을 수 없습니다.');
+    await this.usersRepo.deleteById(userId);
+  }
 }


### PR DESCRIPTION
## 📝 요약
<!--- ex) 내용 설명 -->
- 회원 탈퇴 API 구현

## 📝 변경사항
<!--- ex) 변경사항 -->
- users.repository.ts: deleteById(id: string): Promise<void> 추가
- users.service.ts: deleteMe(userId: string): Promise<void> 구현(존재 확인 후 삭제)
- users.controller.ts: DELETE /api/users/delete 엔드포인트 + AuthGuard('jwt')/RequestWithUser 적용

## 📝 추가설명
<!--- ex) 추가설명 -->


## 🔗관련 이슈
- Closes #103 

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).