### PR TITLE
feat: 관심 스토어 등록  API 구현

### DIFF
--- a/src/store/dto/register-interest-store.dto.ts
+++ b/src/store/dto/register-interest-store.dto.ts
@@ -1,0 +1,12 @@
+export class MyInterestStoreDto {
+  id: string;
+  userId: string;
+  name: string;
+  address: string;
+  phoneNumber: string;
+  content: string;
+  image?: string;
+  createdAt: Date;
+  updatedAt: Date;
+  detailAddress?: string;
+}

--- a/src/store/store.controller.ts
+++ b/src/store/store.controller.ts
@@ -20,6 +20,7 @@ import { StoreResponseDto } from './dto/store-response.dto';
 import { ParseCuidPipe } from 'src/common/pipes/parse-cuid.pipe';
 import { MyStoreProductQueryDto } from './dto/store-product-query.dto';
 import { MyStoreProductListWrapperDto } from './dto/store-product-wrapper.dto';
+import { MyInterestStoreDto } from './dto/register-interest-store.dto';
 
 @Controller('api/stores')
 export class StoreController {
@@ -48,6 +49,16 @@ export class StoreController {
   ): Promise<MyStoreProductListWrapperDto> {
     const { userId, type } = req.user;
     return this.storeService.getMyStoreProducts(userId, type, query);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post(':storeId/favorite')
+  registerInterestStore(
+    @Param('storeId', ParseCuidPipe) storeId: string,
+    @Req() req: { user: AuthUser },
+  ): Promise<{ store: MyInterestStoreDto }> {
+    const user = req.user;
+    return this.storeService.registerInterestStore(storeId, user.userId);
   }
 
   @Get(':storeId')

--- a/src/store/store.repository.ts
+++ b/src/store/store.repository.ts
@@ -125,4 +125,12 @@ export class StoreRepository {
 
     return result._sum?.quantity ?? 0;
   }
+
+  async registerFavoriteStore(storeId: string, userId: string): Promise<void> {
+    await this.prisma.favoriteStore.upsert({
+      where: { userId_storeId: { userId, storeId } },
+      create: { userId, storeId },
+      update: {},
+    });
+  }
 }

--- a/src/store/store.service.ts
+++ b/src/store/store.service.ts
@@ -3,9 +3,10 @@ import {
   NotFoundException,
   ConflictException,
   ForbiddenException,
+  BadRequestException,
   UnauthorizedException,
 } from '@nestjs/common';
-import { UserType, Prisma } from '@prisma/client';
+import { UserType, Prisma, Store } from '@prisma/client';
 import { StoreRepository, ProductListRow } from './store.repository';
 import { CreateStoreDto } from './dto/create-store.dto';
 import { StoreDetailDto } from './dto/store-detail.dto';
@@ -16,6 +17,7 @@ import { MyStoreProductQueryDto } from './dto/store-product-query.dto';
 import { MyStoreProductListItemDto } from './dto/store-product-list.dto';
 import { MyStoreProductListWrapperDto } from './dto/store-product-wrapper.dto';
 import { DateTime } from 'luxon';
+import { MyInterestStoreDto } from './dto/register-interest-store.dto';
 
 @Injectable()
 export class StoreService {
@@ -225,5 +227,39 @@ export class StoreService {
       createdAt: createdAtUTC ?? product.createdAt.toISOString(),
       isSoldOut: stockSum <= 0,
     };
+  }
+
+  private interestStoreDto(store: Store): MyInterestStoreDto {
+    return {
+      id: store.id,
+      userId: store.sellerId,
+      name: store.name,
+      address: store.address,
+      detailAddress: store.detailAddress ?? undefined,
+      phoneNumber: store.phoneNumber,
+      content: store.content,
+      image: store.image ?? undefined,
+      createdAt: store.createdAt,
+      updatedAt: store.updatedAt,
+    };
+  }
+  async registerInterestStore(
+    storeId: string,
+    userId: string,
+  ): Promise<{ store: MyInterestStoreDto }> {
+    const store = await this.storeRepo.findByStoreId(storeId);
+
+    if (!store) throw new NotFoundException('스토어를 찾을 수 없습니다.');
+
+    if (!userId) throw new UnauthorizedException('로그인이 필요합니다.');
+
+    if (store.sellerId === userId)
+      throw new BadRequestException(
+        '자신의 스토어는 관심 등록 할 수 없습니다.',
+      );
+
+    await this.storeRepo.registerFavoriteStore(storeId, userId);
+
+    return { store: this.interestStoreDto(store) };
   }
 }


### PR DESCRIPTION
## 📝 요약
- 관심 스토어 등록 API를 작성했습니다.
- 같은 요청을 여러 번 보내도 중복 없이 한번만 등록되도록 로직을 작성했습니다.

## 📝 변경사항
- 스토어 확인, 자기 스토어 관심 등록 금지 유효성 검증 로직 추가
- 등록 후 Store 엔티티를 MyInterestStoreDto로 매핑해서 { store } 반환

## 📝 추가설명
- 스키마에 작성된 `@@unique([userId, storeId])`를 활용해서 관심 스토어 등록이 중복되지 않습니다.
- ParseCuidPipe가 먼저 실행되어 유효하지 않은 CUID는 컨트롤러 진입 전 400에러로 차단됩니다.
- 리팩토링 시에 파이프 검증을 완화하거나, 예외 필터로 상태코드 매핑을 통일하는 등의 방법을 고려해보겠습니다.

## 🔗관련 이슈
- Closes #99 

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## ✅ 테스트 결과
스토어 관심 등록 
<img width="968" height="467" alt="스크린샷 2025-09-30 오후 10 42 57" src="https://github.com/user-attachments/assets/ebe73625-aca1-4297-bcc2-1dba60587f2b" />

자신의 스토어 관심 등록 안됨
<img width="967" height="336" alt="스크린샷 2025-09-30 오후 10 43 14" src="https://github.com/user-attachments/assets/0bb38b08-c966-47b1-b2e2-310b03a12e3e" />

관심 등록된 스토어 상세 조회 결과
<img width="970" height="539" alt="스크린샷 2025-09-30 오후 10 43 28" src="https://github.com/user-attachments/assets/58888413-56ba-47f7-9130-b8aa248d56dc" />