### PR TITLE
feat: 관심 등록 해제 API 구현

### DIFF
--- a/src/store/store.controller.ts
+++ b/src/store/store.controller.ts
@@ -8,6 +8,7 @@ import {
   Req,
   Get,
   Query,
+  Delete,
 } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt.guard';
 import type { AuthUser } from '../auth/auth.types';
@@ -19,6 +20,7 @@ import { MyStoreDetailDto } from './dto/mystore-detail.dto';
 import { StoreResponseDto } from './dto/store-response.dto';
 import { ParseCuidPipe } from 'src/common/pipes/parse-cuid.pipe';
 import { MyStoreProductQueryDto } from './dto/store-product-query.dto';
+import { MyInterestStoreDto } from './dto/register-interest-store.dto';
 import { MyStoreProductListWrapperDto } from './dto/store-product-wrapper.dto';
 
 @Controller('api/stores')
@@ -48,6 +50,16 @@ export class StoreController {
   ): Promise<MyStoreProductListWrapperDto> {
     const { userId, type } = req.user;
     return this.storeService.getMyStoreProducts(userId, type, query);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Delete(':storeId/favorite')
+  deleteInterestStore(
+    @Param('storeId', ParseCuidPipe) storeId: string,
+    @Req() req: { user: AuthUser },
+  ): Promise<{ store: MyInterestStoreDto }> {
+    const user = req.user;
+    return this.storeService.deleteInterestStore(storeId, user.userId);
   }
 
   @Get(':storeId')

--- a/src/store/store.repository.ts
+++ b/src/store/store.repository.ts
@@ -125,4 +125,10 @@ export class StoreRepository {
 
     return result._sum?.quantity ?? 0;
   }
+
+  async deleteFavoriteStore(storeId: string, userId: string): Promise<void> {
+    await this.prisma.favoriteStore.delete({
+      where: { userId_storeId: { userId, storeId } },
+    });
+  }
 }

--- a/src/store/store.service.ts
+++ b/src/store/store.service.ts
@@ -12,6 +12,7 @@ import { StoreDetailDto } from './dto/store-detail.dto';
 import { MyStoreDetailDto } from './dto/mystore-detail.dto';
 import { UpdateStoreDto } from './dto/update-store.dto';
 import { StoreResponseDto } from './dto/store-response.dto';
+import { MyInterestStoreDto } from './dto/register-interest-store.dto';
 import { MyStoreProductQueryDto } from './dto/store-product-query.dto';
 import { MyStoreProductListItemDto } from './dto/store-product-list.dto';
 import { MyStoreProductListWrapperDto } from './dto/store-product-wrapper.dto';
@@ -225,5 +226,20 @@ export class StoreService {
       createdAt: createdAtUTC ?? product.createdAt.toISOString(),
       isSoldOut: stockSum <= 0,
     };
+  }
+
+  async deleteInterestStore(
+    storeId: string,
+    userId: string,
+  ): Promise<{ store: MyInterestStoreDto }> {
+    const store = await this.storeRepo.findByStoreId(storeId);
+
+    if (!store) throw new NotFoundException('스토어를 찾을 수 없습니다.');
+
+    if (!userId) throw new UnauthorizedException('로그인이 필요합니다.');
+
+    await this.storeRepo.deleteFavoriteStore(storeId, userId);
+
+    return { store: this.interestStoreDto(store) };
   }
 }


### PR DESCRIPTION
## 📝 요약
- 관심 스토어 등록 해제 API를 작성했습니다. 

## 📝 변경사항
- 스토어 확인, 자기 스토어 관심 등록 금지 유효성 검증 로직 추가
- 등록 후 Store 엔티티를 MyInterestStoreDto로 매핑해서 관심등록 해제한 store의 데이터를 { store } 형태로 반환


## 📝 추가설명
- 관심 스토어 등록 API 에서와 마찬가지로  ParseCuidPipe가 먼저 실행되어 유효하지 않은 CUID는 컨트롤러 진입 전 400에러로 차단됩니다.
- 추후 리팩토링 시에 파이프 검증을 완화하거나, 예외 필터로 상태코드 매핑을 통일하는 등의 방법을 고려해보겠습니다.


## 🔗관련 이슈
- Closes #109 

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## ✅ 테스트 결과
[DB] 관심 스토어 등록
<img width="1189" height="196" alt="스크린샷 2025-10-01 오후 1 41 29" src="https://github.com/user-attachments/assets/fff5525e-876a-4ff6-b445-6293994bbcc2" />

[DB] 관심 스토어 등록 해제
<img width="1165" height="142" alt="스크린샷 2025-10-01 오후 1 41 49" src="https://github.com/user-attachments/assets/9e09ef4e-44a3-4f00-a4f8-1dd93534cd5f" />

[Postman] 관심 스토어 등록 해제
<img width="971" height="451" alt="스크린샷 2025-10-01 오후 2 25 05" src="https://github.com/user-attachments/assets/41ea8770-543d-4b6a-9d4c-542bacb3b28c" />
