### PR TITLE
feat: 문의 상세 조회 기능 추가

### DIFF
--- a/src/inquiry/inquiry.controller.ts
+++ b/src/inquiry/inquiry.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query, Req, UseGuards } from '@nestjs/common';
+import { Controller, Get, Param, Query, Req, UseGuards } from '@nestjs/common';
 import { JwtAuthGuard } from 'src/auth/jwt.guard';
 import { AuthUser } from 'src/auth/auth.types';
 import { InquiryService } from './inquiry.service';
@@ -18,5 +18,11 @@ export class InquiryController {
     const user = req.user;
 
     return this.inquiryService.getMyInquiries(user.userId, query);
+  }
+
+  // 문의 상세 조회
+  @Get(':inquiryId')
+  getInquiryDetail(@Param('inquiryId') inquiryId: string) {
+    return this.inquiryService.getInquiryDetail(inquiryId);
   }
 }

--- a/src/inquiry/inquiry.repository.ts
+++ b/src/inquiry/inquiry.repository.ts
@@ -50,4 +50,32 @@ export class InquiryRepository {
 
     return result;
   }
+
+  // 문의 상세 조회
+  async getInquiryById(inquiryId: string) {
+    return this.prisma.inquiry.findUnique({
+      where: { id: inquiryId },
+      select: {
+        id: true,
+        userId: true,
+        productId: true,
+        title: true,
+        content: true,
+        status: true,
+        isSecret: true,
+        createdAt: true,
+        updatedAt: true,
+        user: { select: { nickname: true } },
+        reply: {
+          select: {
+            id: true,
+            content: true,
+            createdAt: true,
+            updatedAt: true,
+            user: { select: { nickname: true } },
+          },
+        },
+      },
+    });
+  }
 }

--- a/src/inquiry/inquiry.service.ts
+++ b/src/inquiry/inquiry.service.ts
@@ -38,7 +38,6 @@ export class InquiryService {
       ...inquiry,
       user: { name: inquiry.user.nickname },
       // TODO : 추후 리팩토링 시 1:1 관계로 스키마 변경 예정
-      // 답변이 없을 경우를 대비한 옵셔널 체이닝
       reply: reply ? { ...reply, user: { name: reply.user.nickname }, } : null,
     };
   }

--- a/src/inquiry/inquiry.service.ts
+++ b/src/inquiry/inquiry.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InquiryRepository } from './inquiry.repository';
 import { GetInquiriesDto } from './inquiry.dto';
 
@@ -23,6 +23,23 @@ export class InquiryService {
     return {
       list: inquiries.list.map(formatInquiries),
       totalCount: inquiries.totalCount,
+    };
+  }
+
+  // 문의 상세 조회
+  async getInquiryDetail(inquiryId: string) {
+    const inquiry = await this.inquiryRepository.getInquiryById(inquiryId);
+    const reply = inquiry?.reply?.length ? inquiry.reply[0] : null;
+
+    // 문의가 존재하지 않거나 접근이 거부된 경우
+    if (!inquiry) throw new NotFoundException('문의가 존재하지 않습니다.');
+
+    return {
+      ...inquiry,
+      user: { name: inquiry.user.nickname },
+      // TODO : 추후 리팩토링 시 1:1 관계로 스키마 변경 예정
+      // 답변이 없을 경우를 대비한 옵셔널 체이닝
+      reply: reply ? { ...reply, user: { name: reply.user.nickname }, } : null,
     };
   }
 }


### PR DESCRIPTION
## 📝 요약
문의 상세 조회 기능 구현

## 📝 변경사항
- InquiryController, InquiryService => getInquiryDetail 추가
- InquiryRepository => getInquiryById 추가

## 📝 추가설명
- 구매자 & 판매자 `마이페이지 > 문의` 페이지에서 사용되는 API
- 문의와 답변 관계는 1:1로 추후 리팩토링 시 변경 예정

## 🔗관련 이슈
- Closes #110 

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).