### PR TITLE
feat: 문의 수정 기능 추가 및 유효성 검사 구현

### DIFF
--- a/src/inquiry/inquiry.controller.ts
+++ b/src/inquiry/inquiry.controller.ts
@@ -1,8 +1,8 @@
-import { Controller, Get, Param, Query, Req, UseGuards } from '@nestjs/common';
+import { BadRequestException, Body, Controller, Get, Param, Patch, Query, Req, UseGuards } from '@nestjs/common';
 import { JwtAuthGuard } from 'src/auth/jwt.guard';
 import { AuthUser } from 'src/auth/auth.types';
 import { InquiryService } from './inquiry.service';
-import { GetInquiriesDto } from './inquiry.dto';
+import { GetInquiriesDto, UpdateInquiryDto } from './inquiry.dto';
 
 @Controller('api/inquiries')
 export class InquiryController {
@@ -24,5 +24,30 @@ export class InquiryController {
   @Get(':inquiryId')
   getInquiryDetail(@Param('inquiryId') inquiryId: string) {
     return this.inquiryService.getInquiryDetail(inquiryId);
+  }
+
+  // 문의 수정
+  @UseGuards(JwtAuthGuard)
+  @Patch(':inquiryId')
+  updateInquiry(
+    @Req() req: { user: AuthUser },
+    @Param('inquiryId') inquiryId: string,
+    @Body() body: UpdateInquiryDto,
+  ) {
+    const userId = req.user.userId;
+    const { title, content, isSecret } = body;
+
+    // 수정 요청 시 최소 1개의 필드가 입력되어야 함
+    if (title === undefined && content === undefined && isSecret === undefined) {
+      throw new BadRequestException('수정할 필드를 최소 1개 이상 입력해주세요.');
+    }
+
+    // undefined 값만 필터링
+    const updateData: Partial<UpdateInquiryDto> = {};
+    if (title !== undefined) updateData.title = title;
+    if (content !== undefined) updateData.content = content;
+    if (isSecret !== undefined) updateData.isSecret = isSecret;
+
+    return this.inquiryService.updateInquiry(userId, inquiryId, updateData);
   }
 }

--- a/src/inquiry/inquiry.dto.ts
+++ b/src/inquiry/inquiry.dto.ts
@@ -1,5 +1,5 @@
 import { AnswerStatus } from "@prisma/client";
-import { IsOptional, IsEnum, IsInt, Min } from "class-validator";
+import { IsOptional, IsEnum, IsInt, Min, IsBoolean, IsString, MinLength } from "class-validator";
 
 export class GetInquiriesDto {
   @IsInt()
@@ -13,4 +13,20 @@ export class GetInquiriesDto {
   @IsOptional()
   @IsEnum(AnswerStatus)
   status?: AnswerStatus;
+}
+
+export class UpdateInquiryDto {
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  title: string;
+
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  content: string;
+
+  @IsOptional()
+  @IsBoolean()
+  isSecret: boolean;
 }

--- a/src/inquiry/inquiry.repository.ts
+++ b/src/inquiry/inquiry.repository.ts
@@ -78,4 +78,11 @@ export class InquiryRepository {
       },
     });
   }
+
+  async updateInquiry(inquiryId: string, title?: string, content?: string, isSecret?: boolean) {
+    return this.prisma.inquiry.update({
+      where: { id: inquiryId },
+      data: { title, content, isSecret },
+    });
+  }
 }

--- a/src/inquiry/inquiry.service.ts
+++ b/src/inquiry/inquiry.service.ts
@@ -1,6 +1,7 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { ConflictException, Injectable, NotFoundException, UnauthorizedException } from '@nestjs/common';
+import { AnswerStatus } from '@prisma/client';
 import { InquiryRepository } from './inquiry.repository';
-import { GetInquiriesDto } from './inquiry.dto';
+import { GetInquiriesDto, UpdateInquiryDto } from './inquiry.dto';
 
 @Injectable()
 export class InquiryService {
@@ -40,5 +41,23 @@ export class InquiryService {
       // TODO : 추후 리팩토링 시 1:1 관계로 스키마 변경 예정
       reply: reply ? { ...reply, user: { name: reply.user.nickname }, } : null,
     };
+  }
+
+  async updateInquiry(userId: string, inquiryId: string, body: Partial<UpdateInquiryDto>) {
+    const { title, content, isSecret } = body;
+    const inquiry = await this.inquiryRepository.getInquiryById(inquiryId);
+    const reply = inquiry?.reply?.length ? inquiry.reply[0] : null;
+
+    // 문의가 존재하지 않는 경우
+    if (!inquiry) throw new NotFoundException('문의가 존재하지 않습니다.');
+
+    // 내가 작성한 문의가 아닌 경우 접근 거부
+    if (inquiry.userId !== userId) throw new UnauthorizedException('자신이 작성한 문의만 수정할 수 있습니다.');
+
+    // 답변이 이미 달린 경우 수정 불가(문의 상태가 답변 완료인 경우 || 답변이 이미 존재하는 경우)
+    if (reply || inquiry.status === AnswerStatus.CompletedAnswer) throw new ConflictException('답변이 이미 달린 문의는 수정할 수 없습니다.');
+
+
+    return this.inquiryRepository.updateInquiry(inquiryId, title, content, isSecret);
   }
 }


### PR DESCRIPTION
## 📝 요약
- 구매자는 자신이 작성한 문의에 한해서 수정 가능
- 판매자가 답변한 경우 수정이 불가함

## 📝 변경사항
- InquiryController, InquiryService, InquiryRepository에 updateInquiry 추가
- UpdateInquiryDto 추가

## 📝 추가설명
- title, content는 업데이트 시 1글자 이상 입력 필수
- 수정 요청 시 최소 1개의 필드가 입력되었는지 검증 진행
- body 데이터에 undefined 값이 포함되지 않도록 컨트롤러에서 필터링 후 서비스로 전달
- ID 검증 파이프 적용

## 🔗관련 이슈
- Closes #117 

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).