### PR TITLE
fix: 등급(Grade) 도메인 분리

### DIFF
--- a/src/common/prisma-tx.type.ts
+++ b/src/common/prisma-tx.type.ts
@@ -1,0 +1,4 @@
+import { Prisma } from '@prisma/client';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+export type TxLike = PrismaService | Prisma.TransactionClient;

--- a/src/grades/grade.constants.ts
+++ b/src/grades/grade.constants.ts
@@ -1,8 +1,7 @@
-// Define GradeLevel as a string literal union matching the enum values used in the code.
-// This avoids importing a non-exported type from @prisma/client.
 export type GradeLevel = 'GREEN' | 'ORANGE' | 'RED' | 'BLACK' | 'VIP';
 
 export type GradePayload = {
+  earnRate: number;
   id: string;
   name: string;
   rate: number;
@@ -10,9 +9,39 @@ export type GradePayload = {
 };
 
 export const GRADE_MAP: Record<GradeLevel, GradePayload> = {
-  GREEN: { id: 'grade_green', name: 'green', rate: 1, minAmount: 0 },
-  ORANGE: { id: 'grade_orange', name: 'orange', rate: 2, minAmount: 100000 },
-  RED: { id: 'grade_red', name: 'red', rate: 3, minAmount: 300000 },
-  BLACK: { id: 'grade_black', name: 'black', rate: 4, minAmount: 500000 },
-  VIP: { id: 'grade_vip', name: 'vip', rate: 5, minAmount: 1000000 },
+  GREEN: {
+    id: 'grade_green',
+    name: 'green',
+    rate: 1,
+    minAmount: 0,
+    earnRate: 0,
+  },
+  ORANGE: {
+    id: 'grade_orange',
+    name: 'orange',
+    rate: 2,
+    minAmount: 100000,
+    earnRate: 0,
+  },
+  RED: {
+    id: 'grade_red',
+    name: 'red',
+    rate: 3,
+    minAmount: 300000,
+    earnRate: 0,
+  },
+  BLACK: {
+    id: 'grade_black',
+    name: 'black',
+    rate: 4,
+    minAmount: 500000,
+    earnRate: 0,
+  },
+  VIP: {
+    id: 'grade_vip',
+    name: 'vip',
+    rate: 5,
+    minAmount: 1000000,
+    earnRate: 0,
+  },
 };

--- a/src/grades/grade.module.ts
+++ b/src/grades/grade.module.ts
@@ -1,10 +1,10 @@
 import { Module } from '@nestjs/common';
 import { GradeService } from './grade.service';
-import { GradeRepo } from './grade.repository';
+import { GradeRepository } from './grade.repository';
 import { PrismaService } from 'src/prisma/prisma.service';
 
 @Module({
-  providers: [GradeService, GradeRepo, PrismaService],
+  providers: [GradeService, GradeRepository, PrismaService],
   exports: [GradeService],
 })
 export class GradeModule {}

--- a/src/grades/grade.module.ts
+++ b/src/grades/grade.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { GradeService } from './grade.service';
+import { GradeRepo } from './grade.repo';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Module({
+  providers: [GradeService, GradeRepo, PrismaService],
+  exports: [GradeService],
+})
+export class GradeModule {}

--- a/src/grades/grade.module.ts
+++ b/src/grades/grade.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
 import { GradeService } from './grade.service';
-import { GradeRepo } from './grade.repo';
+import { GradeRepo } from './grade.repository';
 import { PrismaService } from 'src/prisma/prisma.service';
 
 @Module({

--- a/src/grades/grade.repo.ts
+++ b/src/grades/grade.repo.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@nestjs/common';
+import { GradeLevel } from '@prisma/client';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { TxLike } from 'src/points/points.types';
+import { COUNTED_ORDER_STATUS } from 'src/points/points.types';
+
+@Injectable()
+export class GradeRepo {
+  constructor(private readonly prisma: PrismaService) {}
+
+  get prismaSvc() {
+    return this.prisma;
+  }
+
+  // 등급 산정을 위한 누적 합계
+  async sumLifetime(
+    userId: string,
+    tx: TxLike = this.prisma,
+    thisOrderIdToExclude?: string,
+  ): Promise<number> {
+    const agg = await tx.order.aggregate({
+      where: {
+        userId,
+        status: { in: COUNTED_ORDER_STATUS },
+        ...(thisOrderIdToExclude ? { NOT: { id: thisOrderIdToExclude } } : {}),
+      },
+      _sum: { totalPrice: true },
+    });
+    return agg._sum.totalPrice ?? 0;
+  }
+
+  // 사용자 등급 저장(표시용 캐시)
+  async saveUserGrade(
+    userId: string,
+    level: GradeLevel,
+    tx: TxLike,
+  ): Promise<void> {
+    await tx.user.update({
+      where: { id: userId },
+      data: { gradeLevel: level },
+    });
+  }
+}

--- a/src/grades/grade.repository.ts
+++ b/src/grades/grade.repository.ts
@@ -4,7 +4,7 @@ import { PrismaService } from 'src/prisma/prisma.service';
 import { TxLike } from 'src/common/prisma-tx.type';
 
 @Injectable()
-export class GradeRepo {
+export class GradeRepository {
   constructor(private readonly prisma: PrismaService) {}
 
   get prismaSvc() {

--- a/src/grades/grade.repository.ts
+++ b/src/grades/grade.repository.ts
@@ -1,8 +1,7 @@
 import { Injectable } from '@nestjs/common';
-import { GradeLevel } from '@prisma/client';
+import { GradeLevel, OrderStatus } from '@prisma/client';
 import { PrismaService } from 'src/prisma/prisma.service';
-import { TxLike } from 'src/points/points.types';
-import { COUNTED_ORDER_STATUS } from 'src/points/points.types';
+import { TxLike } from 'src/common/prisma-tx.type';
 
 @Injectable()
 export class GradeRepo {
@@ -21,7 +20,7 @@ export class GradeRepo {
     const agg = await tx.order.aggregate({
       where: {
         userId,
-        status: { in: COUNTED_ORDER_STATUS },
+        status: OrderStatus.COMPLETEDPAYMENT,
         ...(thisOrderIdToExclude ? { NOT: { id: thisOrderIdToExclude } } : {}),
       },
       _sum: { totalPrice: true },

--- a/src/grades/grade.service.ts
+++ b/src/grades/grade.service.ts
@@ -1,12 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { GradeLevel } from '@prisma/client';
-import { GradeRepo } from './grade.repository';
-import { TxLike } from 'src/points/points.types';
+import { GradeRepository } from './grade.repository';
+import { TxLike } from 'src/common/prisma-tx.type';
 import { getEarnRate, getGradeByAmount, getNextGradeInfo } from './grade.util';
 
 @Injectable()
 export class GradeService {
-  constructor(private readonly repo: GradeRepo) {}
+  constructor(private readonly repo: GradeRepository) {}
 
   // 현재 등급 및 누적 구매액 조회
   async getCurrentGrade(

--- a/src/grades/grade.service.ts
+++ b/src/grades/grade.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { GradeLevel } from '@prisma/client';
-import { GradeRepo } from './grade.repo';
+import { GradeRepo } from './grade.repository';
 import { TxLike } from 'src/points/points.types';
 import { getEarnRate, getGradeByAmount, getNextGradeInfo } from './grade.util';
 

--- a/src/grades/grade.service.ts
+++ b/src/grades/grade.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@nestjs/common';
+import { GradeLevel } from '@prisma/client';
+import { GradeRepo } from './grade.repo';
+import { TxLike } from 'src/points/points.types';
+import { getEarnRate, getGradeByAmount, getNextGradeInfo } from './grade.util';
+
+@Injectable()
+export class GradeService {
+  constructor(private readonly repo: GradeRepo) {}
+
+  // 현재 등급 및 누적 구매액 조회
+  async getCurrentGrade(
+    userId: string,
+    tx: TxLike = this.repo.prismaSvc,
+    thisOrderIdToExclude?: string,
+  ): Promise<{ lifetime: number; grade: GradeLevel }> {
+    const lifetime = await this.repo.sumLifetime(
+      userId,
+      tx,
+      thisOrderIdToExclude,
+    );
+    return { lifetime, grade: getGradeByAmount(lifetime) };
+  }
+
+  // 등급별 적립율
+  getEarnRate(level: GradeLevel): number {
+    return getEarnRate(level);
+  }
+
+  // 다음 등급 정보
+  getNextGradeInfo(lifetime: number): { next?: GradeLevel; need?: number } {
+    return getNextGradeInfo(lifetime);
+  }
+
+  // 사용자 등급 저장(표시용 캐시)
+  async syncUserGrade(
+    userId: string,
+    level: GradeLevel,
+    tx: TxLike,
+  ): Promise<void> {
+    await this.repo.saveUserGrade(userId, level, tx);
+  }
+}

--- a/src/grades/grade.util.ts
+++ b/src/grades/grade.util.ts
@@ -4,9 +4,10 @@ export function resolveGradeByAmount(totalAmount: number): {
   level: GradeLevel;
   payload: GradePayload;
 } {
-  // minAmount 오름차순 → 최종적으로 조건을 만족하는 가장 높은 등급으로 갱신
+  // 총 구매금액 기준 등급 산정
+  // minAmount 기준 오름차순 정렬 후, totalAmount 이상인 마지막 등급 선택
   const entries = Object.entries(GRADE_MAP) as [GradeLevel, GradePayload][];
-  // 안전하게 minAmount 순 정렬
+
   entries.sort((a, b) => a[1].minAmount - b[1].minAmount);
 
   let current: [GradeLevel, GradePayload] = entries[0];
@@ -15,4 +16,33 @@ export function resolveGradeByAmount(totalAmount: number): {
   }
   const [level, payload] = current;
   return { level, payload };
+}
+
+// 총 구매금액으로 등급 산정
+export function getGradeByAmount(totalAmount: number): GradeLevel {
+  return resolveGradeByAmount(totalAmount).level;
+}
+
+// 등급별 적립율 반환
+export function getEarnRate(level: GradeLevel): number {
+  return GRADE_MAP[level].earnRate;
+}
+
+// 다음 등급 정보 반환
+export function getNextGradeInfo(totalAmount: number): {
+  next?: GradeLevel;
+  need?: number;
+} {
+  const entries = Object.entries(GRADE_MAP) as [GradeLevel, GradePayload][];
+  entries.sort((a, b) => a[1].minAmount - b[1].minAmount);
+
+  // 현재 등급
+  const { level: current } = resolveGradeByAmount(totalAmount);
+  const idx = entries.findIndex(([lvl]) => lvl === current);
+
+  const next = entries[idx + 1];
+  if (!next) return {};
+  const [nextLevel, nextPayload] = next;
+  const need = Math.max(0, nextPayload.minAmount - totalAmount);
+  return { next: nextLevel, need };
 }


### PR DESCRIPTION
## 📝 요약
<!--- ex) 내용 설명 -->
- 등급(Grade) 도메인을 포인트와 분리하여 모듈화하고, 결제완료/취소 흐름에 등급 계산·동기화를 연동했습니다.

## 📝 변경사항
<!--- ex) 변경사항 -->
- grades 모듈 신규
   - grade.module.ts DI/exports 구성
   - grade.repo.ts 누적금액 집계(sumLifetime), 등급 캐시 저장
   - grade.service.ts 현재등급 계산(주문제외 옵션), 적립률/다음등급 제공

## 📝 추가설명
<!--- ex) 추가설명 -->


## 🔗관련 이슈
- Closes #125 

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).