### PR TITLE
refactor: User 모델의 nickname 컬럼 -> name으로 변경

### DIFF
--- a/prisma/migrations/20251014080132_rename_user_nickname_to_name/migration.sql
+++ b/prisma/migrations/20251014080132_rename_user_nickname_to_name/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `nickname` on the `User` table. All the data in the column will be lost.
+  - Added the required column `name` to the `User` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."User" DROP COLUMN "nickname",
+ADD COLUMN     "name" TEXT NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,7 +20,7 @@ datasource db {
  */
 model User {
   id           String     @id @default(cuid())
-  nickname     String
+  name         String
   email        String     @unique
   passwordHash String
   type         UserType   @default(BUYER)

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -48,7 +48,7 @@ export class AuthService {
     return {
       id: u.id,
       email: u.email,
-      name: u.nickname,
+      name: u.name,
       type: u.type as 'BUYER' | 'SELLER',
       points: String(u.points),
       image: u.image ?? null,

--- a/src/users/users.mapper.ts
+++ b/src/users/users.mapper.ts
@@ -14,7 +14,7 @@ export type UserPayload = {
 export const toUserPayload = (u: User): UserPayload => ({
   id: u.id,
   email: u.email,
-  name: u.nickname,
+  name: u.name,
   type: u.type,
   points: String(u.points),
   image: u.image ?? null,

--- a/src/users/users.repository.ts
+++ b/src/users/users.repository.ts
@@ -5,7 +5,7 @@ import { USER_AUTH_SELECT, FAVORITE_WITH_STORE_SELECT } from './users.select';
 
 export type UserForAuth = Pick<
   User,
-  'id' | 'email' | 'nickname' | 'type' | 'gradeLevel' | 'passwordHash'
+  'id' | 'email' | 'name' | 'type' | 'gradeLevel' | 'passwordHash'
 >;
 
 // favorite + store select 결과 타입 (정적 타입 안전)

--- a/src/users/users.select.ts
+++ b/src/users/users.select.ts
@@ -3,7 +3,7 @@ import type { Prisma } from '@prisma/client';
 export const USER_AUTH_SELECT: Prisma.UserSelect = {
   id: true,
   email: true,
-  nickname: true,
+  name: true,
   type: true,
   gradeLevel: true,
   passwordHash: true,

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -33,7 +33,7 @@ export class UsersService {
     const userType: UserType = dto.type ?? 'BUYER';
 
     const created = await this.usersRepo.create({
-      nickname: dto.name,
+      name: dto.name,
       email,
       passwordHash,
       type: userType,
@@ -59,7 +59,7 @@ export class UsersService {
     }
 
     const data: Prisma.UserUpdateInput = {};
-    if (dto.name) data.nickname = dto.name;
+    if (dto.name) data.name = dto.name;
     if (dto.image !== undefined) data.image = dto.image;
     if (dto.password) {
       data.passwordHash = await bcrypt.hash(dto.password, 10);


### PR DESCRIPTION
## 📝 요약
<!--- ex) 내용 설명 -->
- User 모델 컬럼을 nickname → name으로 리네임하고 관련 참조를 일괄 수정했습니다.

## 📝 변경사항
<!--- ex) 변경사항 -->
- schema.prisma: User.nickname → User.name
- Prisma 마이그레이션 추가: rename_user_nickname_to_name
- 서비스/컨트롤러/DTO 등 nickname 참조 전부 name으로 변경

## 📝 추가설명
<!--- ex) 추가설명 -->
**- pull 받은 뒤 필수: npx prisma generate**

## 🔗관련 이슈
- Closes #111 

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).