### PR TITLE
feat: 알람 API 구현 (실시간 알람 SSE, 유저타입에 따른 알람 조회, 알람 읽음 처리)

### DIFF
--- a/prisma/migrations/20251014013147_fix_notification_table/migration.sql
+++ b/prisma/migrations/20251014013147_fix_notification_table/migration.sql
@@ -1,0 +1,56 @@
+/*
+  Warnings:
+
+  - The values [ORDER_UPDATE,PROMOTION,SYSTEM_ALERT] on the enum `NotificationType` will be removed. If these variants are still used in the database, this will fail.
+  - A unique constraint covering the columns `[userId,type,productId,inquiryId,orderId,storeId]` on the table `Notification` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterEnum
+BEGIN;
+CREATE TYPE "public"."NotificationType_new" AS ENUM ('OUT_OF_STOCK_CART', 'OUT_OF_STOCK_ORDER', 'OUT_OF_STOCK_SELLER', 'NEW_INQUIRY', 'INQUIRY_ANSWERED', 'SYSTEM');
+ALTER TABLE "public"."Notification" ALTER COLUMN "type" TYPE "public"."NotificationType_new" USING ("type"::text::"public"."NotificationType_new");
+ALTER TYPE "public"."NotificationType" RENAME TO "NotificationType_old";
+ALTER TYPE "public"."NotificationType_new" RENAME TO "NotificationType";
+DROP TYPE "public"."NotificationType_old";
+COMMIT;
+
+-- AlterTable
+ALTER TABLE "public"."Notification" ADD COLUMN     "inquiryId" TEXT,
+ADD COLUMN     "orderId" TEXT,
+ADD COLUMN     "productId" TEXT,
+ADD COLUMN     "readAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "storeId" TEXT,
+ADD COLUMN     "title" TEXT;
+
+-- CreateIndex
+CREATE INDEX "Notification_userId_isRead_createdAt_idx" ON "public"."Notification"("userId", "isRead", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "Notification_type_idx" ON "public"."Notification"("type");
+
+-- CreateIndex
+CREATE INDEX "Notification_productId_idx" ON "public"."Notification"("productId");
+
+-- CreateIndex
+CREATE INDEX "Notification_inquiryId_idx" ON "public"."Notification"("inquiryId");
+
+-- CreateIndex
+CREATE INDEX "Notification_orderId_idx" ON "public"."Notification"("orderId");
+
+-- CreateIndex
+CREATE INDEX "Notification_storeId_idx" ON "public"."Notification"("storeId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Notification_userId_type_productId_inquiryId_orderId_storeI_key" ON "public"."Notification"("userId", "type", "productId", "inquiryId", "orderId", "storeId");
+
+-- AddForeignKey
+ALTER TABLE "public"."Notification" ADD CONSTRAINT "Notification_productId_fkey" FOREIGN KEY ("productId") REFERENCES "public"."Product"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Notification" ADD CONSTRAINT "Notification_inquiryId_fkey" FOREIGN KEY ("inquiryId") REFERENCES "public"."Inquiry"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Notification" ADD CONSTRAINT "Notification_orderId_fkey" FOREIGN KEY ("orderId") REFERENCES "public"."Order"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Notification" ADD CONSTRAINT "Notification_storeId_fkey" FOREIGN KEY ("storeId") REFERENCES "public"."Store"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20251014050124_notif_add_updated_at_fix_read_at/migration.sql
+++ b/prisma/migrations/20251014050124_notif_add_updated_at_fix_read_at/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - Added the required column `updatedAt` to the `Notification` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."Notification" ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL,
+ALTER COLUMN "readAt" DROP NOT NULL,
+ALTER COLUMN "readAt" DROP DEFAULT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -108,9 +108,10 @@ model Store {
   sellerId String @unique
   seller   User   @relation("StoreOwner", fields: [sellerId], references: [id], onDelete: Cascade)
 
-  favorites FavoriteStore[]
-  Product   Product[]
-  Order     Order[]
+  favorites    FavoriteStore[]
+  Product      Product[]
+  Order        Order[]
+  Notification Notification[]
 }
 
 model FavoriteStore {
@@ -152,9 +153,10 @@ model CartItem {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  cart    Cart    @relation(fields: [cartId], references: [id], onDelete: Cascade)
-  product Product @relation(fields: [productId], references: [id], onDelete: Restrict)
+  cart    Cart      @relation(fields: [cartId], references: [id], onDelete: Cascade)
+  product Product   @relation(fields: [productId], references: [id], onDelete: Restrict)
   size    StockSize @relation(fields: [sizeId], references: [id], onDelete: Cascade)
+
   @@unique([cartId, productId, sizeId])
 }
 
@@ -167,7 +169,7 @@ model Product {
   id                String    @id @default(cuid())
   storeId           String
   name              String
-  content           String?        
+  content           String?
   image             String?
   price             Int
   discountPrice     Int?
@@ -178,14 +180,15 @@ model Product {
   createdAt         DateTime  @default(now())
   updatedAt         DateTime  @updatedAt
 
-  store      Store       @relation(fields: [storeId], references: [id], onDelete: Cascade)
-  categoryId String
-  category   Category    @relation(fields: [categoryId], references: [id], onDelete: Cascade)
-  stocks     Stock[]
-  reviews    Review[]
-  inquiries  Inquiry[]
-  cartItems  CartItem[]
-  orderItems OrderItem[]
+  store        Store          @relation(fields: [storeId], references: [id], onDelete: Cascade)
+  categoryId   String
+  category     Category       @relation(fields: [categoryId], references: [id], onDelete: Cascade)
+  stocks       Stock[]
+  reviews      Review[]
+  inquiries    Inquiry[]
+  cartItems    CartItem[]
+  orderItems   OrderItem[]
+  Notification Notification[]
 }
 
 model Category {
@@ -205,24 +208,22 @@ enum CategoryType {
 }
 
 model Stock {
-  id        String   @id @default(cuid())
+  id        String    @id @default(cuid())
   productId String
   sizeId    String
   size      StockSize @relation(fields: [sizeId], references: [id], onDelete: Cascade)
   quantity  Int
 
   product Product @relation(fields: [productId], references: [id], onDelete: Cascade)
-  
 }
 
 model StockSize {
-  id String @id @default(cuid())
+  id   String @id @default(cuid())
   name String
 
   stocks    Stock[]
   cartItems CartItem[]
 }
-
 
 /**
  * =========================
@@ -230,34 +231,35 @@ model StockSize {
  * =========================
  */
 model Order {
-   id             String   @id @default(cuid())  
+  id             String @id @default(cuid())
   userId         String
   storeId        String
-  recipientName  String   
-  recipientPhone String   
-  address        String   
-  subtotal       Int       
-  totalQuantity  Int       
-  usePoint       Int       @default(0) 
-  totalPrice     Int       
+  recipientName  String
+  recipientPhone String
+  address        String
+  subtotal       Int
+  totalQuantity  Int
+  usePoint       Int    @default(0)
+  totalPrice     Int
 
-  status         OrderStatus  @default(PROCESSING)
-  createdAt      DateTime     @default(now())
-  updatedAt      DateTime     @updatedAt
+  status    OrderStatus @default(PROCESSING)
+  createdAt DateTime    @default(now())
+  updatedAt DateTime    @updatedAt
 
-  user        User       @relation(fields: [userId], references: [id], onDelete: Cascade)
-  store       Store      @relation(fields: [storeId], references: [id], onDelete: Cascade)
-  items       OrderItem[]
-  pointLogs   PointTransaction[]
-  payments    Payment?
+  user         User               @relation(fields: [userId], references: [id], onDelete: Cascade)
+  store        Store              @relation(fields: [storeId], references: [id], onDelete: Cascade)
+  items        OrderItem[]
+  pointLogs    PointTransaction[]
+  payments     Payment?
+  Notification Notification[]
 }
 
 model Payment {
-  id        String         @id @default(cuid())
-  orderId   String         @unique
+  id        String        @id @default(cuid())
+  orderId   String        @unique
   price     Int
-  status    PaymentStatus  @default(PENDING)
-  createdAt DateTime       @default(now())
+  status    PaymentStatus @default(PENDING)
+  createdAt DateTime      @default(now())
 
   order Order @relation(fields: [orderId], references: [id], onDelete: Cascade)
 }
@@ -274,7 +276,7 @@ model OrderItem {
   orderId   String
   productId String
   quantity  Int
-  price     Int        // 주문 당시 가격 (할인 반영 가능)
+  price     Int // 주문 당시 가격 (할인 반영 가능)
 
   order   Order   @relation(fields: [orderId], references: [id], onDelete: Cascade)
   product Product @relation(fields: [productId], references: [id], onDelete: Restrict)
@@ -293,20 +295,44 @@ enum OrderStatus {
  * =========================
  */
 model Notification {
-  id        String           @id @default(cuid())
-  userId    String
-  type      NotificationType
-  message   String
-  isRead    Boolean          @default(false)
-  createdAt DateTime         @default(now())
+  id      String           @id @default(cuid())
+  userId  String
+  type    NotificationType
+  title   String?
+  message String
 
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  productId String?
+  inquiryId String?
+  orderId   String?
+  storeId   String?
+
+  isRead    Boolean  @default(false)
+  readAt    DateTime?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  user    User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  product Product? @relation(fields: [productId], references: [id], onDelete: SetNull)
+  inquiry Inquiry? @relation(fields: [inquiryId], references: [id], onDelete: SetNull)
+  order   Order?   @relation(fields: [orderId], references: [id], onDelete: SetNull)
+  store   Store?   @relation(fields: [storeId], references: [id], onDelete: SetNull)
+
+  @@unique([userId, type, productId, inquiryId, orderId, storeId])
+  @@index([userId, isRead, createdAt])
+  @@index([type])
+  @@index([productId])
+  @@index([inquiryId])
+  @@index([orderId])
+  @@index([storeId])
 }
 
 enum NotificationType {
-  ORDER_UPDATE
-  PROMOTION
-  SYSTEM_ALERT
+  OUT_OF_STOCK_CART
+  OUT_OF_STOCK_ORDER
+  OUT_OF_STOCK_SELLER
+  NEW_INQUIRY
+  INQUIRY_ANSWERED
+  SYSTEM
 }
 
 /**
@@ -347,11 +373,12 @@ model Inquiry {
   createdAt DateTime     @default(now())
   updatedAt DateTime     @updatedAt
 
-  userId    String
-  user      User     @relation("InquiryAuthor", fields: [userId], references: [id], onDelete: Cascade)
-  productId String
-  product   Product  @relation(fields: [productId], references: [id], onDelete: Cascade)
-  reply     Answer[]
+  userId       String
+  user         User           @relation("InquiryAuthor", fields: [userId], references: [id], onDelete: Cascade)
+  productId    String
+  product      Product        @relation(fields: [productId], references: [id], onDelete: Cascade)
+  reply        Answer[]
+  Notification Notification[]
 }
 
 model Answer {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,6 +12,7 @@ import { ReviewModule } from './review/review.module';
 import { DashboardModule } from './dashboard/dashboard.module';
 import { GradeModule } from 'src/grades/grade.module';
 import { PointsModule } from 'src/points/points.module';
+import { NotificationsModule } from './notifications/notifications.module';
 
 @Module({
   imports: [
@@ -29,6 +30,7 @@ import { PointsModule } from 'src/points/points.module';
     DashboardModule,
     GradeModule,
     PointsModule,
+    NotificationsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/notifications/notifications.controller.spec.ts
+++ b/src/notifications/notifications.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotificationsController } from './notifications.controller';
+
+describe('NotificationsController', () => {
+  let controller: NotificationsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [NotificationsController],
+    }).compile();
+
+    controller = module.get<NotificationsController>(NotificationsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/notifications/notifications.controller.ts
+++ b/src/notifications/notifications.controller.ts
@@ -1,0 +1,55 @@
+import { JwtAuthGuard } from './../auth/jwt.guard';
+import {
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Sse,
+  UnauthorizedException,
+  UseGuards,
+} from '@nestjs/common';
+import { NotificationsService } from './notifications.service';
+import { CurrentUser } from 'src/auth/current-user.decorator';
+import type { AuthUser } from 'src/auth/auth.types';
+import { interval, startWith, switchMap } from 'rxjs';
+import type { MessageEvent as SseMessageEvent } from '@nestjs/common';
+
+@UseGuards(JwtAuthGuard)
+@Controller('api/notifications')
+export class NotificationsController {
+  constructor(private readonly notifications: NotificationsService) {}
+
+  // 30초마다 미확인 알림 전송
+  @Sse('sse')
+  sse(@CurrentUser() user: AuthUser) {
+    if (!user?.userId) throw new UnauthorizedException('인증 실패했습니다.');
+
+    return interval(30000).pipe(
+      startWith(0),
+      switchMap(async (): Promise<SseMessageEvent> => {
+        const data = await this.notifications.unread(user.userId);
+        return { id: String(Date.now()), type: 'notifications', data };
+      }),
+    );
+  }
+
+  // 목록 조회
+  @Get()
+  async list(@CurrentUser() user: AuthUser) {
+    if (!user?.userId) throw new UnauthorizedException('인증 실패했습니다.');
+
+    return this.notifications.list(user.userId);
+  }
+
+  // 읽음 처리
+  @Patch(':alarmId/check')
+  async check(
+    @CurrentUser() user: AuthUser,
+    @Param('alarmId') alarmId: string,
+  ) {
+    if (!user?.userId) throw new UnauthorizedException('인증 실패했습니다.');
+
+    await this.notifications.check(user.userId, alarmId);
+    return { message: '알람 읽음 처리 완료' };
+  }
+}

--- a/src/notifications/notifications.mapper.ts
+++ b/src/notifications/notifications.mapper.ts
@@ -1,0 +1,19 @@
+import { Notification } from '@prisma/client';
+
+export type AlarmResponse = {
+  id: string;
+  userId: string;
+  content: string;
+  isChecked: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export const toAlarmResponse = (n: Notification): AlarmResponse => ({
+  id: n.id,
+  userId: n.userId,
+  content: n.message,
+  isChecked: n.isRead,
+  createdAt: n.createdAt.toISOString(),
+  updatedAt: n.updatedAt.toISOString(),
+});

--- a/src/notifications/notifications.module.ts
+++ b/src/notifications/notifications.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { NotificationsController } from './notifications.controller';
+import { NotificationsService } from './notifications.service';
+import { NotificationsRepository } from './notifications.repository';
+import { PrismaModule } from 'src/prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [NotificationsController],
+  providers: [NotificationsService, NotificationsRepository],
+  exports: [NotificationsService],
+})
+export class NotificationsModule {}

--- a/src/notifications/notifications.repository.ts
+++ b/src/notifications/notifications.repository.ts
@@ -1,0 +1,57 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { NotificationType, UserType } from '@prisma/client';
+
+@Injectable()
+export class NotificationsRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findByIdAndAndUser(alarmId: string, userId: string) {
+    return this.prisma.notification.findFirst({
+      where: { id: alarmId, userId },
+    });
+  }
+
+  async findUserType(userId: string): Promise<UserType> {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { type: true },
+    });
+
+    if (!user) throw new Error('User not found');
+    return user.type;
+  }
+
+  async findMany(params: {
+    userId: string;
+    isRead?: boolean;
+    types?: NotificationType[];
+  }) {
+    const { userId, isRead, types } = params;
+    return this.prisma.notification.findMany({
+      where: {
+        userId,
+        ...(typeof isRead === 'boolean' ? { isRead } : {}),
+        ...(types?.length ? { type: { in: types } } : {}),
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  async markRead(id: string) {
+    return this.prisma.notification.update({
+      where: { id },
+      data: { isRead: true, readAt: new Date() },
+    });
+  }
+
+  async findOneOwnedOfAllowed(
+    userId: string,
+    id: string,
+    allowed: NotificationType[],
+  ) {
+    return this.prisma.notification.findFirst({
+      where: { id, userId, type: { in: allowed } },
+    });
+  }
+}

--- a/src/notifications/notifications.repository.ts
+++ b/src/notifications/notifications.repository.ts
@@ -6,7 +6,7 @@ import { NotificationType, UserType } from '@prisma/client';
 export class NotificationsRepository {
   constructor(private readonly prisma: PrismaService) {}
 
-  async findByIdAndAndUser(alarmId: string, userId: string) {
+  async findByIdAndUser(alarmId: string, userId: string) {
     return this.prisma.notification.findFirst({
       where: { id: alarmId, userId },
     });

--- a/src/notifications/notifications.repository.ts
+++ b/src/notifications/notifications.repository.ts
@@ -44,14 +44,4 @@ export class NotificationsRepository {
       data: { isRead: true, readAt: new Date() },
     });
   }
-
-  async findOneOwnedOfAllowed(
-    userId: string,
-    id: string,
-    allowed: NotificationType[],
-  ) {
-    return this.prisma.notification.findFirst({
-      where: { id, userId, type: { in: allowed } },
-    });
-  }
 }

--- a/src/notifications/notifications.service.spec.ts
+++ b/src/notifications/notifications.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotificationsService } from './notifications.service';
+
+describe('NotificationsService', () => {
+  let service: NotificationsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [NotificationsService],
+    }).compile();
+
+    service = module.get<NotificationsService>(NotificationsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/notifications/notifications.service.ts
+++ b/src/notifications/notifications.service.ts
@@ -1,0 +1,57 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { NotificationsRepository } from './notifications.repository';
+import { toAlarmResponse } from './notifications.mapper';
+import { allowedByUserType } from './types/allowed-types.type';
+
+@Injectable()
+export class NotificationsService {
+  constructor(private readonly repository: NotificationsRepository) {}
+
+  async unread(userId: string) {
+    const userType = await this.repository.findUserType(userId);
+    const allowed = allowedByUserType(userType);
+
+    if (!allowed?.length) throw new ForbiddenException('접근 권한이 없습니다.');
+
+    const list = await this.repository.findMany({
+      userId,
+      isRead: false,
+      types: allowed,
+    });
+    return list.map(toAlarmResponse);
+  }
+
+  async list(userId: string) {
+    if (!userId) throw new BadRequestException('잘못된 요청 입니다.');
+
+    const userType = await this.repository.findUserType(userId);
+    const allowed = allowedByUserType(userType);
+    if (!allowed?.length)
+      throw new ForbiddenException('사용자를 찾지 못했습니다.');
+
+    const list = await this.repository.findMany({ userId, types: allowed });
+
+    if (!list.length) throw new NotFoundException('알람을 찾지 못했습니다.');
+
+    return list.map(toAlarmResponse);
+  }
+
+  async check(userId: string, alarmId: string) {
+    const alarm = await this.repository.findByIdAndAndUser(alarmId, userId);
+    if (!alarm) throw new NotFoundException('해당 알람이 없습니다.');
+
+    const userType = await this.repository.findUserType(userId);
+    const allowed = allowedByUserType(userType);
+    if (!allowed?.length)
+      throw new ForbiddenException('사용자를 찾지 못했습니다.');
+
+    if (alarm.isRead) throw new BadRequestException('잘못된 요청 입니다.');
+
+    await this.repository.markRead(alarm.id);
+  }
+}

--- a/src/notifications/types/allowed-types.type.ts
+++ b/src/notifications/types/allowed-types.type.ts
@@ -1,0 +1,17 @@
+import { NotificationType, UserType } from '@prisma/client';
+
+export const BUYER_ALLOWED: NotificationType[] = [
+  'OUT_OF_STOCK_CART',
+  'OUT_OF_STOCK_ORDER',
+  'INQUIRY_ANSWERED',
+  'SYSTEM',
+];
+
+export const SELLER_ALLOWED: NotificationType[] = [
+  'NEW_INQUIRY',
+  'OUT_OF_STOCK_SELLER',
+  'SYSTEM',
+];
+
+export const allowedByUserType = (userType: UserType): NotificationType[] =>
+  userType === 'SELLER' ? SELLER_ALLOWED : BUYER_ALLOWED;


### PR DESCRIPTION
## 📝 요약
- 알림 기능 구현: SSE 실시간 전송(30초), 유저 타입별 조회 필터, 알림 읽음 처리

## 📝 변경사항
- 알람 구조 : 누구에게(유저) > 무엇을(알람 타입) > 어떤 리소스(상품, 문의, 주문, 스토어)
- Notification 스키마 보정 : 관련 리소스 FK(productId, inquiryId, orderId, storeId) 추가
  - 타입 세분화(OUT_OF_STOCK_CART, OUT_OF_STOCK_ORDER, NEW_INQUIRY, INQUIRY_ANSWERED, SYSTEM)
  - isRead, readAt, createdAt, updatedAt 정리 및 인덱스, 유니크 키 구성
 - 역할 기반 필터링: allowedByUserType(BUYER/SELLER) >  실시간 전송, 목록 조회, 읽음 처리에 적용
 - 응답 매퍼: DB(message, isRead) > API(content, isChecked)

## 🔗관련 이슈
- Closes #133 

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## ✅ 테스트 결과
실시간 알람
<img width="1432" height="816" alt="스크린샷 2025-10-14 오후 5 48 02" src="https://github.com/user-attachments/assets/08d8a35e-d421-4352-8127-4df667d28f73" />

유저 타입에 따른 알람 조회
<img width="1431" height="666" alt="스크린샷 2025-10-14 오후 5 48 21" src="https://github.com/user-attachments/assets/b32e3f6e-9ae1-45a8-afcf-e3b2763aa91b" />

알람 읽음 처리
<img width="1431" height="530" alt="스크린샷 2025-10-14 오후 5 48 37" src="https://github.com/user-attachments/assets/0389040a-41aa-4a82-9f32-3c2b2c444e9b" />