### PR TITLE
feat: 스토어api 유닛 테스트 작성(+README에 테스트 커버리지 추가)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,49 @@
+name: Test & Coverage Badges
+on:
+  push:
+    branches: ['dev']
+  pull_request:
+    branches: ['dev']
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Run unit tests with coverage (non-blocking)
+        run: npm run test:ci
+        continue-on-error: true
+
+      - name: Update README coverage badges
+        if: always()
+        run: |
+          if [ -f coverage/coverage-summary.json ]; then
+            npm run test:badge
+          else
+            echo "coverage-summary.json not found. Skip badge update."
+          fi
+
+      - name: Commit README update
+        if: github.event_name == 'push' && github.ref == 'refs/heads/dev' && hashFiles('coverage/coverage-summary.json') != ''
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: '[TEST] update test coverage'
+          branch: dev
+          file_pattern: README.md

--- a/README.md
+++ b/README.md
@@ -96,3 +96,11 @@ Nest is an MIT-licensed open source project. It can grow thanks to the sponsors 
 ## License
 
 Nest is [MIT licensed](https://github.com/nestjs/nest/blob/master/LICENSE).
+
+
+## Test Coverage
+<!-- COVERAGE:START -->
+| Statements | Branches | Functions | Lines |
+| -----------|----------|-----------|-------|
+| ![Statements](#statements# "Make me better!") | ![Branches](#branches# "Make me better!") | ![Functions](#functions# "Make me better!") | ![Lines](#lines# "Make me better!") |
+<!-- COVERAGE:END -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "eslint-config-prettier": "^10.0.1",
         "eslint-plugin-prettier": "^5.2.2",
         "globals": "^16.0.0",
+        "istanbul-badges-readme": "^1.9.0",
         "jest": "^30.0.0",
         "prettier": "^3.4.2",
         "prisma": "^6.16.2",
@@ -8547,6 +8548,16 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-badges-readme": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/istanbul-badges-readme/-/istanbul-badges-readme-1.9.0.tgz",
+      "integrity": "sha512-sD9lTsFajcfK07euJReQ0C9dy0VmXViMDJk67EZseGRC+jv+esxt5I3Viqoi1b43m5in5ek5b+0rpxJi41bJVw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "istanbul-badges-readme": "lib/index.js"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",

--- a/package.json
+++ b/package.json
@@ -18,9 +18,11 @@
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "dotenv -e .env.test.local -- prisma migrate dev && dotenv -e .env.test.local -- jest",
     "test:watch": "jest --watch",
-    "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
+    "coverage": "jest --coverage",
+    "test:ci": "jest --coverage --runInBand --coverageReporters=json-summary --coverageReporters=lcov --coverageReporters=text-summary --testFailureExitCode=0",
+    "test:badge": "istanbul-badges-readme --coverageDir=./coverage --readmeDir=./",
     "seed": "ts-node --transpile-only prisma/seed.ts && ts-node --transpile-only prisma/seedForDashboard.ts"
   },
   "dependencies": {
@@ -68,6 +70,7 @@
     "eslint-config-prettier": "^10.0.1",
     "eslint-plugin-prettier": "^5.2.2",
     "globals": "^16.0.0",
+    "istanbul-badges-readme": "^1.9.0",
     "jest": "^30.0.0",
     "prettier": "^3.4.2",
     "prisma": "^6.16.2",

--- a/src/inquiry/inquiry.dto.ts
+++ b/src/inquiry/inquiry.dto.ts
@@ -1,5 +1,13 @@
-import { AnswerStatus } from "@prisma/client";
-import { IsOptional, IsEnum, IsInt, Min, IsBoolean, IsString, MinLength } from "class-validator";
+import { AnswerStatus } from '@prisma/client';
+import {
+  IsOptional,
+  IsEnum,
+  IsInt,
+  Min,
+  IsBoolean,
+  IsString,
+  MinLength,
+} from 'class-validator';
 
 export class GetInquiriesDto {
   @IsInt()
@@ -14,8 +22,6 @@ export class GetInquiriesDto {
   @IsEnum(AnswerStatus)
   status?: AnswerStatus;
 }
-<<<<<<< HEAD
-=======
 
 export class UpdateInquiryDto {
   @IsOptional()
@@ -38,4 +44,3 @@ export class ReplyContentDto {
   @MinLength(1)
   content: string;
 }
->>>>>>> upstream/dev

--- a/src/store/store.controller.spec.ts
+++ b/src/store/store.controller.spec.ts
@@ -1,0 +1,111 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { StoreController } from './store.controller';
+import { StoreService } from './store.service';
+import type { AuthUser } from '../auth/auth.types';
+import { UserType } from '@prisma/client';
+
+describe('StoreController', () => {
+  let controller: StoreController;
+  let service: jest.Mocked<StoreService>;
+
+  const mockService: jest.Mocked<StoreService> = {
+    createStore: jest.fn(),
+    updateStore: jest.fn(),
+    getStoreDetail: jest.fn(),
+    getMyStoreDetail: jest.fn(),
+    getMyStoreProducts: jest.fn(),
+    registerInterestStore: jest.fn(),
+    deleteInterestStore: jest.fn(),
+  } as any;
+
+  const req = (over?: Partial<AuthUser>) => ({
+    user: { userId: 'u1', type: UserType.SELLER, ...(over ?? {}) } as AuthUser,
+  });
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [StoreController],
+      providers: [{ provide: StoreService, useValue: mockService }],
+    }).compile();
+
+    controller = module.get(StoreController);
+    service = module.get(StoreService) as any;
+    jest.clearAllMocks();
+  });
+
+  it('스토어 등록', async () => {
+    service.createStore.mockResolvedValue({ id: 's1' } as any);
+    const dto = {
+      name: 'New Store',
+      address: '서울특별시 용산구',
+      detailAddress: '서빙고로 137',
+      phoneNumber: '02-0000-0000',
+      content: '트렌디한 백자를 판매합니다.',
+    } as any;
+    const result = await controller.create(req(), dto);
+    expect(service.createStore).toHaveBeenCalledWith(
+      'u1',
+      UserType.SELLER,
+      dto,
+    );
+    expect(result).toEqual({ id: 's1' });
+  });
+
+  it('내 스토어 상세 조회', async () => {
+    service.getMyStoreDetail.mockResolvedValue({ id: 's1' } as any);
+    await controller.getMyStoreDetail(req());
+    expect(service.getMyStoreDetail).toHaveBeenCalledWith(
+      'u1',
+      UserType.SELLER,
+    );
+  });
+
+  it('스토어에 등록된 상품 목록 조회', async () => {
+    service.getMyStoreProducts.mockResolvedValue({ list: [], totalCount: 0 });
+    const query = { page: 2, pageSize: 5 } as any;
+    await controller.getMyStoreProducts(req(), query);
+    expect(service.getMyStoreProducts).toHaveBeenCalledWith(
+      'u1',
+      UserType.SELLER,
+      query,
+    );
+  });
+
+  it('스토어 상세 조회', async () => {
+    service.getStoreDetail.mockResolvedValue({ id: 's1' } as any);
+    await controller.getStoreDetail('s1');
+    expect(service.getStoreDetail).toHaveBeenCalledWith('s1');
+  });
+
+  it('스토어 수정', async () => {
+    service.updateStore.mockResolvedValue({ id: 's1' } as any);
+    const dto = { name: 'new' } as any;
+    await controller.updateStore(
+      's1',
+      { user: { userId: 'u1', type: UserType.SELLER } } as any,
+      dto,
+    );
+    expect(service.updateStore).toHaveBeenCalledWith(
+      's1',
+      'u1',
+      UserType.SELLER,
+      dto,
+    );
+  });
+
+  it('관심 스토어 등록', async () => {
+    service.registerInterestStore.mockResolvedValue({
+      store: { id: 's1' } as any,
+    });
+    await controller.registerInterestStore('s1', req());
+    expect(service.registerInterestStore).toHaveBeenCalledWith('s1', 'u1');
+  });
+
+  it('관심 스토어 해제', async () => {
+    service.deleteInterestStore.mockResolvedValue({
+      store: { id: 's1' } as any,
+    });
+    await controller.deleteInterestStore('s1', req());
+    expect(service.deleteInterestStore).toHaveBeenCalledWith('s1', 'u1');
+  });
+});

--- a/src/store/store.controller.ts
+++ b/src/store/store.controller.ts
@@ -21,7 +21,7 @@ import { StoreResponseDto } from './dto/store-response.dto';
 import { MyInterestStoreDto } from './dto/register-interest-store.dto';
 import { MyStoreProductQueryDto } from './dto/store-product-query.dto';
 import { MyStoreProductListWrapperDto } from './dto/store-product-wrapper.dto';
-import { ParseCuidPipe } from 'src/common/pipes/parse-cuid.pipe';
+import { ParseCuidPipe } from '../common/pipes/parse-cuid.pipe';
 
 @Controller('api/stores')
 export class StoreController {

--- a/src/store/store.service.spec.ts
+++ b/src/store/store.service.spec.ts
@@ -1,0 +1,292 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { StoreService } from './store.service';
+import { StoreRepository, ProductListRow } from './store.repository';
+import { UserType } from '@prisma/client';
+import {
+  ForbiddenException,
+  ConflictException,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Settings } from 'luxon';
+
+describe('StoreService', () => {
+  let service: StoreService;
+  let repo: jest.Mocked<StoreRepository>;
+
+  const mockRepo: jest.Mocked<StoreRepository> = {
+    getBySellerId: jest.fn(),
+    createStore: jest.fn(),
+    updateStore: jest.fn(),
+    findByStoreId: jest.fn(),
+    findBySellerId: jest.fn(),
+    findStoreIdBySellerId: jest.fn(),
+    countProductByStoreId: jest.fn(),
+    findProductPageByStoreId: jest.fn(),
+    findStockRowsForProductsIds: jest.fn(),
+    favoriteCounts: jest.fn(),
+    productCounts: jest.fn(),
+    monthFavoriteCounts: jest.fn(),
+    totalSoldCounts: jest.fn(),
+    registerFavoriteStore: jest.fn(),
+    deleteFavoriteStore: jest.fn(),
+  } as any;
+
+  beforeAll(() => {
+    Settings.now = () => Date.now();
+  });
+
+  afterAll(() => {
+    Settings.now = () => Date.now();
+  });
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StoreService,
+        { provide: StoreRepository, useValue: mockRepo },
+      ],
+    }).compile();
+
+    service = module.get(StoreService);
+    repo = module.get(StoreRepository) as any;
+    jest.clearAllMocks();
+  });
+
+  describe('스토어 등록', () => {
+    it('판매자만 생성 가능하고, 하나의 스토어만 생성 가능', async () => {
+      repo.getBySellerId.mockResolvedValue(false);
+      repo.createStore.mockResolvedValue({ id: 's1', sellerId: 'u1' } as any);
+
+      const dto = {
+        name: 'New Store',
+        address: '서울특별시 용산구',
+        phoneNumber: '02-0000-0000',
+      } as any;
+      const result = await service.createStore('u1', UserType.SELLER, dto);
+
+      expect(repo.getBySellerId).toHaveBeenCalledWith('u1');
+      expect(repo.createStore).toHaveBeenCalled();
+      expect(result).toEqual({ id: 's1', sellerId: 'u1' });
+    });
+
+    it('이미 스토어 존재 ConflictException', async () => {
+      repo.getBySellerId.mockResolvedValue(true);
+      await expect(
+        service.createStore('u1', UserType.SELLER, {} as any),
+      ).rejects.toBeInstanceOf(ConflictException);
+    });
+
+    it('판매자 ForbiddenException', async () => {
+      await expect(
+        service.createStore('u1', UserType.BUYER, {} as any),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+  });
+
+  // 판매자 forbidden이랑 unauthorized랑 차이점은? 
+  describe('스토어 수정', () => {
+    it('판매자 ForbiddenException', async () => {
+      await expect(
+        service.updateStore('s1', 'u1', UserType.BUYER, {} as any),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('스토어 없음 NotFoundException', async () => {
+      repo.findByStoreId.mockResolvedValue(null);
+      await expect(
+        service.updateStore('s1', 'u1', UserType.SELLER, {} as any),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('판매자 불일치 UnauthorizedException', async () => {
+      repo.findByStoreId.mockResolvedValue({
+        id: 's1',
+        sellerId: 'other',
+      } as any);
+      await expect(
+        service.updateStore('s1', 'u1', UserType.SELLER, {} as any),
+      ).rejects.toBeInstanceOf(UnauthorizedException);
+    });
+
+    it('부분 업데이트', async () => {
+      repo.findByStoreId.mockResolvedValue({ id: 's1', sellerId: 'u1' } as any);
+      repo.updateStore.mockResolvedValue({
+        id: 's1',
+        name: 'new store',
+        sellerId: 'u1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        address: null,
+        detailAddress: null,
+        phoneNumber: null,
+        content: null,
+        image: null,
+      } as any);
+
+      await service.updateStore('s1', 'u1', UserType.SELLER, {
+        name: 'new store',
+      } as any);
+
+      expect(repo.updateStore).toHaveBeenCalledWith(
+        's1',
+        expect.objectContaining({ name: 'new store' }),
+      );
+      expect(repo.updateStore).not.toHaveBeenCalledWith(
+        's1',
+        expect.objectContaining({ address: expect.anything() }),
+      );
+    });
+  });
+
+  describe('스토어 상세 조회', () => {
+    it('스웨거 명세대로 반환', async () => {
+      const base = {
+        id: 's1',
+        name: 'new store',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        sellerId: 'u1',
+        address: '서울시 용산구',
+        detailAddress: '서빙고로 137',
+        phoneNumber: '02-0000-0000',
+        content: 'C',
+        image: null,
+      } as any;
+      repo.findByStoreId.mockResolvedValue(base);
+      repo.favoriteCounts.mockResolvedValue(3);
+
+      const res = await service.getStoreDetail('s1');
+      expect(repo.favoriteCounts).toHaveBeenCalledWith('s1');
+      expect(res.favoriteCount).toBe(3);
+      expect(res.id).toBe('s1');
+    });
+
+    it('존재하지 않는 스토어 NotFoundException', async () => {
+      repo.findByStoreId.mockResolvedValue(null);
+      await expect(service.getStoreDetail('x')).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('내 스토어 상세 조회', () => {
+    it('판매자 ForbiddenException', async () => {
+      await expect(
+        service.getMyStoreDetail('u1', UserType.BUYER),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('존재하지 않는 스토어 NotFoundException', async () => {
+      repo.findBySellerId.mockResolvedValue(null);
+      await expect(
+        service.getMyStoreDetail('u1', UserType.SELLER),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('스토어에 등록된 상품', () => {
+    it('재고 합계, 품절 여부, 할인기간', async () => {
+      repo.findStoreIdBySellerId.mockResolvedValue('s1');
+      repo.countProductByStoreId.mockResolvedValue(2);
+
+      const products: ProductListRow[] = [
+        {
+          id: 'p1',
+          name: 'product1',
+          image: null,
+          price: 1000,
+          discountPrice: null,
+          discountRate: 10,
+          discountStartTime: new Date('2025-10-01T00:00:00Z'),
+          discountEndTime: new Date('2025-10-31T23:59:59Z'),
+          createdAt: new Date('2025-10-10T00:00:00Z'),
+        },
+        {
+          id: 'p2',
+          name: 'product2',
+          image: null,
+          price: 2000,
+          discountPrice: null,
+          discountRate: null,
+          discountStartTime: null,
+          discountEndTime: null,
+          createdAt: new Date('2025-10-09T00:00:00Z'),
+        },
+      ];
+      repo.findProductPageByStoreId.mockResolvedValue(products);
+      repo.findStockRowsForProductsIds.mockResolvedValue([
+        { productId: 'p1', quantity: 2 },
+        { productId: 'p1', quantity: 3 },
+        { productId: 'p2', quantity: -5 },
+      ]);
+
+      const res = await service.getMyStoreProducts('u1', UserType.SELLER, {
+        page: 1,
+        pageSize: 10,
+      } as any);
+      expect(res.totalCount).toBe(2);
+      expect(res.list).toHaveLength(2);
+
+      const a = res.list.find((x) => x.id === 'p1')!;
+      const b = res.list.find((x) => x.id === 'p2')!;
+      expect(a.stock).toBe(5);
+      expect(a.isDiscount).toBe(true);
+      expect(a.isSoldOut).toBe(false);
+
+      expect(b.stock).toBe(-5);
+      expect(b.isDiscount).toBe(false);
+      expect(b.isSoldOut).toBe(true);
+    });
+
+    it('제품 0개면 빈 배열로 목록 반환', async () => {
+      repo.findStoreIdBySellerId.mockResolvedValue('s1');
+      repo.countProductByStoreId.mockResolvedValue(0);
+      repo.findProductPageByStoreId.mockResolvedValue([]);
+      const res = await service.getMyStoreProducts('u1', UserType.SELLER, {
+        page: 1,
+        pageSize: 10,
+      } as any);
+      expect(res).toEqual({ list: [], totalCount: 0 });
+    });
+
+    it('판매자 아님 ForbiddenException', async () => {
+      await expect(
+        service.getMyStoreProducts('u1', UserType.BUYER, {
+          page: 1,
+          pageSize: 10,
+        } as any),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('등록된 스토어 없음 NotFoundException', async () => {
+      repo.findStoreIdBySellerId.mockResolvedValue(null);
+      await expect(
+        service.getMyStoreProducts('u1', UserType.SELLER, {
+          page: 1,
+          pageSize: 10,
+        } as any),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('스토어 관심 등록', () => {
+    it('자기 스토어에 관심 등록 BadRequest', async () => {
+      repo.findByStoreId.mockResolvedValue({ id: 's1', sellerId: 'u1' } as any);
+      await expect(service.registerInterestStore('s1', 'u1')).rejects.toThrow(
+        '자신의 스토어는 관심 등록 할 수 없습니다.',
+      );
+    });
+
+    // 스토어 관심 등록 정상 플로우 추가 필요
+
+    it('스토어 관심 해제', async () => {
+      repo.findByStoreId.mockResolvedValue({
+        id: 's1',
+        sellerId: 'owner',
+      } as any);
+      await service.deleteInterestStore('s1', 'u1');
+      expect(repo.deleteFavoriteStore).toHaveBeenCalledWith('s1', 'u1');
+    });
+  });
+});

--- a/src/store/store.service.spec.ts
+++ b/src/store/store.service.spec.ts
@@ -84,7 +84,6 @@ describe('StoreService', () => {
     });
   });
 
-  // 판매자 forbidden이랑 unauthorized랑 차이점은? 
   describe('스토어 수정', () => {
     it('판매자 ForbiddenException', async () => {
       await expect(
@@ -277,8 +276,6 @@ describe('StoreService', () => {
         '자신의 스토어는 관심 등록 할 수 없습니다.',
       );
     });
-
-    // 스토어 관심 등록 정상 플로우 추가 필요
 
     it('스토어 관심 해제', async () => {
       repo.findByStoreId.mockResolvedValue({


### PR DESCRIPTION
## 📝 요약
- 스토어 api 컨트롤러, 서비스 유닛 테스트를 작성했습니다.
- Jest 테스트 커버리지 자동 배지 업데이트 기능을 추가하고, README에 커버리지를 표시했습니다.

## 📝 변경사항
- `store.controller.spec.ts`, `store.service.spec.ts` 유닛 테스트 코드 추가 : 스웨거에 작성된 엔드포인트 기준으로 요청, 응답 흐름 검증
- package.json에 test:ci, test:badge 스크립트 추가
- istanbul-badges-readme 패키지 추가
- test.yml 워크플로우 추가 : 테스트 실행, README 자동 업데이트
- README.md에 커버리지 섹션 추가

## 📝 추가설명
- 테스트 실패 시에도 커버리지 배지를 자동 갱신하도록 설정했습니다.
- dev 브랜치로 푸시할 때 워크플로우가 자동 실행되어 최신 커버리지 결과가 README에 반영됩니다.

## 🔗관련 이슈
- Closes #147 

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## ✅ 테스트 결과
<img width="369" height="297" alt="스크린샷 2025-10-16 오전 9 22 52" src="https://github.com/user-attachments/assets/0a3400a0-991d-4af7-8f06-de6f94fbaff3" />
<img width="540" height="524" alt="스크린샷 2025-10-16 오전 9 23 16" src="https://github.com/user-attachments/assets/6ddec9b7-b54e-46d9-9e3f-7ee849e45c98" />
<img width="486" height="132" alt="스크린샷 2025-10-16 오전 9 50 24" src="https://github.com/user-attachments/assets/e6ef0a36-461e-4254-8b3f-2699f20019b3" />

<img width="853" height="155" alt="스크린샷 2025-10-16 오후 2 36 44" src="https://github.com/user-attachments/assets/13481d51-092d-425e-badc-5674d00acd1b" />
