### PR TITLE
test: users, auth 유닛 테스트 추가

### DIFF
--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -1,0 +1,133 @@
+import { Test } from '@nestjs/testing';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import type { Response } from 'express';
+import type { RequestWithCookies, RequestWithUser } from './auth.types';
+import { LoginDto } from './dto/login.dto';
+import type { UserPayload } from './auth.service';
+
+jest.mock('./cookie.util', () => {
+  return {
+    setRefreshCookie: jest.fn<void, [Response, string]>(),
+    clearRefreshCookie: jest.fn<void, [Response]>(),
+    REFRESH_COOKIE_NAME: 'rt',
+  };
+});
+
+import {
+  setRefreshCookie,
+  clearRefreshCookie,
+  REFRESH_COOKIE_NAME,
+} from './cookie.util';
+
+const aUserPayload = (over: Partial<UserPayload> = {}): UserPayload => ({
+  id: 'u1',
+  email: 'test@example.com',
+  name: '홍길동',
+  type: 'BUYER',
+  points: '0',
+  image: null,
+  grade: { id: 'GREEN', name: 'GREEN', rate: 0, minAmount: 0 },
+  ...over,
+});
+
+type AuthServiceMock = jest.Mocked<
+  Pick<AuthService, 'login' | 'refresh' | 'logout'>
+>;
+
+describe('AuthController', () => {
+  let controller: AuthController;
+  let service: AuthServiceMock;
+
+  const makeRes = (): Response =>
+    ({
+      cookie: jest.fn(),
+      clearCookie: jest.fn(),
+    }) as unknown as Response;
+
+  const makeCookieReq = (rt?: string): RequestWithCookies =>
+    ({
+      cookies: rt ? { [REFRESH_COOKIE_NAME]: rt } : {},
+    }) as RequestWithCookies;
+
+  const makeUserReq = (userId: string): RequestWithUser =>
+    ({
+      user: { userId },
+    }) as RequestWithUser;
+
+  beforeEach(async () => {
+    const serviceMock: AuthServiceMock = {
+      login: jest.fn(),
+      refresh: jest.fn(),
+      logout: jest.fn(),
+    };
+
+    const moduleRef = await Test.createTestingModule({
+      controllers: [AuthController],
+      providers: [{ provide: AuthService, useValue: serviceMock }],
+    }).compile();
+
+    controller = moduleRef.get(AuthController);
+    service = moduleRef.get(AuthService);
+
+    jest.clearAllMocks();
+  });
+
+  it('POST /login - 성공 시 setRefreshCookie 호출 및 accessToken 반환', async () => {
+    service.login.mockResolvedValue({
+      user: aUserPayload({ id: 'u1' }),
+      accessToken: 'at',
+      refreshToken: 'rtok',
+    });
+
+    const dto: LoginDto = { email: 'e', password: 'p' };
+    const res = makeRes();
+
+    const out = await controller.login(dto, res);
+
+    expect(service.login).toHaveBeenCalledWith('e', 'p');
+    expect(setRefreshCookie).toHaveBeenCalledWith(res, 'rtok');
+
+    expect(out).toMatchObject({ user: { id: 'u1' }, accessToken: 'at' });
+  });
+
+  it('POST /refresh - 쿠키 없으면 400', async () => {
+    const req = makeCookieReq(undefined);
+    const res = makeRes();
+
+    await expect(controller.refresh(req, res)).rejects.toThrow(
+      'Refresh token cookie missing',
+    );
+  });
+
+  it('POST /refresh - RT 읽어서 서비스 호출, 새 RT로 교체', async () => {
+    service.refresh.mockResolvedValue({
+      accessToken: 'newAT',
+      refreshToken: 'newRT',
+    });
+
+    const req = makeCookieReq('oldRT');
+    const res = makeRes();
+
+    const out = await controller.refresh(req, res);
+
+    expect(service.refresh).toHaveBeenCalledWith('oldRT');
+    expect(setRefreshCookie).toHaveBeenCalledWith(res, 'newRT');
+    expect(out).toEqual({ accessToken: 'newAT' });
+  });
+
+  it('POST /logout - 서비스 호출 및 쿠키 삭제', async () => {
+    service.logout.mockResolvedValue({
+      message: '성공적으로 로그아웃되었습니다.',
+    });
+
+    const req = makeUserReq('u1');
+    const res = makeRes();
+
+    const out = await controller.logout(req, res);
+
+    expect(service.logout).toHaveBeenCalledWith('u1');
+    expect(clearRefreshCookie).toHaveBeenCalledWith(res);
+    expect(out).toEqual({ message: '성공적으로 로그아웃되었습니다.' });
+  });
+});

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -1,0 +1,262 @@
+import { Test } from '@nestjs/testing';
+import { AuthService } from './auth.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { JwtService } from '@nestjs/jwt';
+import { UnauthorizedException } from '@nestjs/common';
+
+// Prisma 관련 타입
+interface DbUser {
+  id: string;
+  email: string;
+  name: string;
+  type: 'BUYER' | 'SELLER';
+  points: number;
+  image: string | null;
+  gradeLevel: string;
+  passwordHash: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+interface SessionRow {
+  userId: string;
+  refreshToken: string;
+  expiresAt: Date;
+}
+
+type UserFindUniqueArgs = { where: { email?: string; id?: string } };
+type SessionCreateArgs = { data: SessionRow };
+type SessionFindUniqueArgs = { where: { refreshToken: string } };
+type SessionUpdateArgs = {
+  where: { refreshToken: string };
+  data: { refreshToken: string; expiresAt: Date };
+};
+type SessionDeleteArgs = { where: { refreshToken: string } };
+type SessionDeleteManyArgs = { where: { userId: string } };
+
+// PrismaService mock 타입
+type PrismaMock = {
+  user: {
+    findUnique: jest.Mock<Promise<DbUser | null>, [UserFindUniqueArgs]>;
+  };
+  session: {
+    create: jest.Mock<Promise<{ id: string }>, [SessionCreateArgs]>;
+    findUnique: jest.Mock<Promise<SessionRow | null>, [SessionFindUniqueArgs]>;
+    update: jest.Mock<Promise<unknown>, [SessionUpdateArgs]>;
+    delete: jest.Mock<Promise<unknown>, [SessionDeleteArgs]>;
+    deleteMany: jest.Mock<Promise<{ count: number }>, [SessionDeleteManyArgs]>;
+  };
+};
+
+const createPrismaMock = (): PrismaMock => ({
+  user: {
+    findUnique: jest.fn<Promise<DbUser | null>, [UserFindUniqueArgs]>(),
+  },
+  session: {
+    create: jest.fn<Promise<{ id: string }>, [SessionCreateArgs]>(),
+    findUnique: jest.fn<Promise<SessionRow | null>, [SessionFindUniqueArgs]>(),
+    update: jest.fn<Promise<unknown>, [SessionUpdateArgs]>(),
+    delete: jest.fn<Promise<unknown>, [SessionDeleteArgs]>(),
+    deleteMany: jest.fn<Promise<{ count: number }>, [SessionDeleteManyArgs]>(),
+  },
+});
+
+const createJwtMock = (): jest.Mocked<JwtService> =>
+  ({
+    signAsync: jest.fn<Promise<string>, [unknown, unknown?]>(() =>
+      Promise.resolve('signed.access'),
+    ),
+  }) as unknown as jest.Mocked<JwtService>;
+
+// bcrypt mock (require-await/스프레드 회피)
+const bcryptCompare = jest.fn(
+  (plain: string, hash: string): Promise<boolean> =>
+    Promise.resolve(hash === `hashed:${plain}`),
+);
+const bcryptHash = jest.fn(
+  (plain: string): Promise<string> => Promise.resolve(`hashed:${plain}`),
+);
+
+jest.mock('bcrypt', () => ({
+  compare: (plain: string, hash: string) => bcryptCompare(plain, hash),
+  hash: (plain: string) => bcryptHash(plain),
+}));
+
+// 도메인 더미/헬퍼
+const aDbUser = (over: Partial<DbUser> = {}): DbUser => ({
+  id: 'u1',
+  email: 'test@example.com',
+  name: '홍길동',
+  type: 'BUYER',
+  points: 0,
+  image: null,
+  gradeLevel: 'GREEN',
+  passwordHash: 'hashed:password123!',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...over,
+});
+
+// 테스트 반환 타입 헬퍼
+type LoginResult = Awaited<ReturnType<AuthService['login']>>;
+type RefreshResult = Awaited<ReturnType<AuthService['refresh']>>;
+type LogoutResult = Awaited<ReturnType<AuthService['logout']>>;
+
+// 테스트
+describe('AuthService', () => {
+  let service: AuthService;
+  let prisma: PrismaMock;
+  let jwt: jest.Mocked<JwtService>;
+
+  beforeEach(async () => {
+    prisma = createPrismaMock();
+    jwt = createJwtMock();
+
+    process.env.JWT_SECRET = 'secret';
+    process.env.JWT_EXPIRES_IN = '1h';
+    process.env.REFRESH_EXPIRES_DAYS = '7';
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        AuthService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: JwtService, useValue: jwt },
+      ],
+    }).compile();
+
+    service = moduleRef.get(AuthService);
+    jest.clearAllMocks();
+  });
+
+  describe('login', () => {
+    it('이메일 없음 → Unauthorized', async () => {
+      prisma.user.findUnique.mockResolvedValue(null);
+
+      await expect(service.login('no@e.com', 'pw')).rejects.toBeInstanceOf(
+        UnauthorizedException,
+      );
+    });
+
+    it('비밀번호 불일치 → Unauthorized', async () => {
+      prisma.user.findUnique.mockResolvedValue(
+        aDbUser({ passwordHash: 'hashed:other' }),
+      );
+
+      await expect(
+        service.login('test@example.com', 'password123!'),
+      ).rejects.toBeInstanceOf(UnauthorizedException);
+    });
+
+    it('성공 → access/refresh 발급 + 세션 저장', async () => {
+      prisma.user.findUnique.mockResolvedValue(aDbUser());
+      prisma.session.create.mockResolvedValue({ id: 's1' });
+
+      const out: LoginResult = await service.login(
+        'test@example.com',
+        'password123!',
+      );
+
+      const signCalls = (jwt.signAsync as jest.Mock).mock.calls.length;
+      expect(signCalls).toBe(1);
+
+      const createCalls = (prisma.session.create as jest.Mock).mock.calls;
+      expect(createCalls.length).toBe(1);
+
+      type CreateArg = Parameters<PrismaMock['session']['create']>[0];
+      const [createArg] = createCalls[0] as [CreateArg];
+
+      expect(createArg.data.userId).toBe('u1');
+      expect(typeof createArg.data.refreshToken).toBe('string');
+      expect(createArg.data.expiresAt).toBeInstanceOf(Date);
+
+      expect(out.user.id).toBe('u1');
+      expect(out.accessToken).toBe('signed.access');
+      expect(out.refreshToken).toEqual(expect.any(String));
+    });
+  });
+
+  describe('refresh', () => {
+    it('세션 없음/만료 → Unauthorized', async () => {
+      prisma.session.findUnique.mockResolvedValue(null);
+
+      await expect(service.refresh('badRT')).rejects.toBeInstanceOf(
+        UnauthorizedException,
+      );
+    });
+
+    it('유저 없음 → 세션 삭제 후 Unauthorized', async () => {
+      const row: SessionRow = {
+        userId: 'u-x',
+        refreshToken: 'rt',
+        expiresAt: new Date(Date.now() + 100_000),
+      };
+      prisma.session.findUnique.mockResolvedValue(row);
+      prisma.user.findUnique.mockResolvedValue(null);
+      prisma.session.delete.mockResolvedValue({});
+
+      await expect(service.refresh('rt')).rejects.toBeInstanceOf(
+        UnauthorizedException,
+      );
+
+      expect(prisma.session.delete).toHaveBeenCalledWith({
+        where: { refreshToken: 'rt' },
+      });
+    });
+
+    it('성공 → RT 로테이션 + AT 재발급', async () => {
+      const row: SessionRow = {
+        userId: 'u1',
+        refreshToken: 'rt',
+        expiresAt: new Date(Date.now() + 100_000),
+      };
+      prisma.session.findUnique.mockResolvedValue(row);
+      prisma.user.findUnique.mockResolvedValue(aDbUser());
+      prisma.session.update.mockResolvedValue({});
+
+      const out: RefreshResult = await service.refresh('rt');
+
+      // 검증
+      const updateCalls = (prisma.session.update as jest.Mock).mock.calls;
+      expect(updateCalls.length).toBe(1);
+
+      type UpdateArg = Parameters<PrismaMock['session']['update']>[0];
+      const [updateArg] = updateCalls[0] as [UpdateArg];
+
+      expect(updateArg.where.refreshToken).toBe('rt');
+      expect(typeof updateArg.data.refreshToken).toBe('string');
+      expect(updateArg.data.expiresAt).toBeInstanceOf(Date);
+
+      const times = (jwt.signAsync as jest.Mock).mock.calls.length;
+      expect(times).toBe(1);
+
+      expect(out.accessToken).toBe('signed.access');
+      expect(out.refreshToken).toEqual(expect.any(String));
+    });
+
+    it('만료된 세션 → Unauthorized', async () => {
+      const expired: SessionRow = {
+        userId: 'u1',
+        refreshToken: 'rt',
+        expiresAt: new Date(Date.now() - 1_000),
+      };
+      prisma.session.findUnique.mockResolvedValue(expired);
+
+      await expect(service.refresh('rt')).rejects.toBeInstanceOf(
+        UnauthorizedException,
+      );
+    });
+  });
+
+  describe('logout', () => {
+    it('세션 삭제', async () => {
+      prisma.session.deleteMany.mockResolvedValue({ count: 2 });
+
+      const out: LogoutResult = await service.logout('u1');
+
+      expect(prisma.session.deleteMany).toHaveBeenCalledWith({
+        where: { userId: 'u1' },
+      });
+      expect(out).toEqual({ message: '성공적으로 로그아웃되었습니다.' });
+    });
+  });
+});

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -1,0 +1,145 @@
+import { Test } from '@nestjs/testing';
+import { UsersController } from './users.controller';
+import { UsersService } from './users.service';
+import type { CreateUserDto } from './dto/create-user.dto';
+import type { UpdateUserDto } from './dto/update-user.dto';
+import type { AuthUser } from '../auth/auth.types';
+import type { UserPayload } from './users.mapper';
+
+// 도메인 더미/헬퍼
+const aUserPayload = (over: Partial<UserPayload> = {}): UserPayload => ({
+  id: 'u1',
+  email: 'test@example.com',
+  name: '홍길동',
+  type: 'BUYER',
+  points: '0',
+  image: null,
+  grade: { id: 'GREEN', name: 'GREEN', rate: 0, minAmount: 0 },
+  ...over,
+});
+
+const makeAuthUser = (userId: string): AuthUser => ({
+  userId,
+  email: 'test@example.com',
+  type: 'BUYER',
+  points: 0,
+  grade: {
+    id: '',
+    name: '',
+    rate: 0,
+    minAmount: 0,
+  },
+});
+
+// Service Mock 타입 정의
+type UsersServiceMock = jest.Mocked<
+  Pick<
+    UsersService,
+    'create' | 'getMe' | 'updateMe' | 'getMyLikes' | 'deleteMe' | 'findById'
+  >
+>;
+
+// 테스트
+describe('UsersController', () => {
+  let controller: UsersController;
+  let service: UsersServiceMock;
+
+  beforeEach(async () => {
+    const svc: UsersServiceMock = {
+      create: jest.fn(),
+      getMe: jest.fn(),
+      updateMe: jest.fn(),
+      getMyLikes: jest.fn(),
+      deleteMe: jest.fn(),
+      findById: jest.fn(),
+    };
+
+    const moduleRef = await Test.createTestingModule({
+      controllers: [UsersController],
+      providers: [{ provide: UsersService, useValue: svc }],
+    }).compile();
+
+    controller = moduleRef.get(UsersController);
+    service = moduleRef.get(UsersService);
+
+    jest.clearAllMocks();
+  });
+
+  it('POST /api/users - 회원가입 위임', async () => {
+    const dto: CreateUserDto = {
+      email: 'new@ex.com',
+      password: 'pw1234',
+      name: '새유저',
+      type: 'BUYER',
+    };
+    service.create.mockResolvedValue({ user: aUserPayload({ id: 'u100' }) });
+
+    const out = await controller.signup(dto);
+
+    const calls = service.create.mock.calls;
+    expect(calls.length).toBe(1);
+    const [arg0] = calls[0] as [CreateUserDto];
+    expect(arg0).toEqual(dto);
+
+    expect(out.user.id).toBe('u100');
+  });
+
+  it('GET /api/users/me - 내 정보', async () => {
+    const me = aUserPayload();
+    service.getMe.mockResolvedValue(me);
+    const authUser = makeAuthUser('u1');
+
+    const out = await controller.getMe(authUser);
+
+    const calls = service.getMe.mock.calls;
+    expect(calls.length).toBe(1);
+    const [uid] = calls[0] as [string];
+    expect(uid).toBe('u1');
+
+    expect(out.id).toBe('u1');
+  });
+
+  it('PATCH /api/users/me - 내 정보 수정', async () => {
+    const authUser = makeAuthUser('u1');
+    const dto: UpdateUserDto = { name: '바뀐이름', currentPassword: 'curPw' };
+    service.updateMe.mockResolvedValue(aUserPayload({ name: '바뀐이름' }));
+
+    const out = await controller.updateMe(authUser, dto);
+
+    const calls = service.updateMe.mock.calls;
+    expect(calls.length).toBe(1);
+    const [uid, body] = calls[0] as [string, UpdateUserDto];
+    expect(uid).toBe('u1');
+    expect(body).toEqual(dto);
+
+    expect(out.name).toBe('바뀐이름');
+  });
+
+  it('GET /api/users/me/likes - 관심 스토어 목록', async () => {
+    const authUser = makeAuthUser('u1');
+    service.getMyLikes.mockResolvedValue([]);
+
+    const out = await controller.getMyLikes(authUser);
+
+    const calls = service.getMyLikes.mock.calls;
+    expect(calls.length).toBe(1);
+    const [uid] = calls[0] as [string];
+    expect(uid).toBe('u1');
+
+    expect(out).toEqual([]);
+  });
+
+  it('DELETE /api/users/delete - 회원 탈퇴', async () => {
+    const authUser = makeAuthUser('u1');
+    service.deleteMe.mockResolvedValue(undefined);
+
+    const out = await controller.deleteMe(authUser);
+
+    const calls = service.deleteMe.mock.calls;
+    expect(calls.length).toBe(1);
+    const [uid] = calls[0] as [string];
+    expect(uid).toBe('u1');
+
+    expect(out).toEqual({ message: '회원 탈퇴가 완료되었습니다.' });
+  });
+});

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -1,0 +1,312 @@
+import { Test } from '@nestjs/testing';
+import { UsersService } from './users.service';
+import { UsersRepository } from './users.repository';
+import {
+  ConflictException,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import type { Prisma, User, UserType, GradeLevel } from '@prisma/client';
+import type { CreateUserDto } from './dto/create-user.dto';
+import type { UpdateUserDto } from './dto/update-user.dto';
+import { toUserPayload, type UserPayload } from './users.mapper';
+
+// bcrypt Mock
+const bcryptCompare = jest.fn(
+  (plain: string, hash: string): Promise<boolean> =>
+    Promise.resolve(hash === `hashed:${plain}`),
+);
+const bcryptHash = jest.fn(
+  (plain: string, saltOrRounds: number): Promise<string> => {
+    void saltOrRounds;
+    return Promise.resolve(`hashed:${plain}`);
+  },
+);
+jest.mock('bcrypt', () => ({
+  compare: (plain: string, hash: string) => bcryptCompare(plain, hash),
+  hash: (plain: string, saltOrRounds: number) =>
+    bcryptHash(plain, saltOrRounds),
+}));
+
+// 도메인 타입/더미/헬퍼
+type DbUser = User;
+
+const aDbUser = (over: Partial<DbUser> = {}): DbUser => ({
+  id: 'u1',
+  email: 'test@example.com',
+  name: '홍길동',
+  type: 'BUYER' as UserType,
+  points: 0,
+  image: null,
+  passwordHash: 'hashed:pw1234!',
+  gradeLevel: 'GREEN' as GradeLevel,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  deletedAt: null,
+  ...over,
+});
+
+const payloadOf = (u: DbUser): UserPayload => toUserPayload(u);
+
+// UsersRepository Mock
+type UsersRepoMock = {
+  existsByEmail: jest.Mock<Promise<boolean>, [string]>;
+  create: jest.Mock<
+    Promise<DbUser>,
+    [
+      {
+        name: string;
+        email: string;
+        passwordHash: string;
+        type: UserType;
+        image: string | null;
+      },
+    ]
+  >;
+  findById: jest.Mock<Promise<DbUser | null>, [string]>;
+  updateById: jest.Mock<Promise<DbUser>, [string, Prisma.UserUpdateInput]>;
+  findLikesByUserId: jest.Mock<Promise<any[]>, [string]>;
+  deleteById: jest.Mock<Promise<void>, [string]>;
+};
+
+const createRepoMock = (): UsersRepoMock => ({
+  existsByEmail: jest.fn<Promise<boolean>, [string]>(),
+  create: jest.fn<
+    Promise<DbUser>,
+    [
+      {
+        name: string;
+        email: string;
+        passwordHash: string;
+        type: UserType;
+        image: string | null;
+      },
+    ]
+  >(),
+  findById: jest.fn<Promise<DbUser | null>, [string]>(),
+  updateById: jest.fn<Promise<DbUser>, [string, Prisma.UserUpdateInput]>(),
+  findLikesByUserId: jest.fn<Promise<any[]>, [string]>(),
+  deleteById: jest.fn<Promise<void>, [string]>(),
+});
+
+// 테스트용 타입
+type CreateReturn = Awaited<ReturnType<UsersService['create']>>;
+type GetMeReturn = Awaited<ReturnType<UsersService['getMe']>>;
+type UpdateMeReturn = Awaited<ReturnType<UsersService['updateMe']>>;
+
+// 테스트
+describe('UsersService', () => {
+  let service: UsersService;
+  let repo: UsersRepoMock;
+
+  beforeEach(async () => {
+    repo = createRepoMock();
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [UsersService, { provide: UsersRepository, useValue: repo }],
+    }).compile();
+
+    service = moduleRef.get(UsersService);
+    jest.clearAllMocks();
+  });
+
+  describe('create (회원가입)', () => {
+    it('이메일 중복이면 ConflictException', async () => {
+      repo.existsByEmail.mockResolvedValue(true);
+
+      const dto: CreateUserDto = {
+        email: 'dup@example.com',
+        password: 'pw',
+        name: 'dup',
+        type: 'BUYER',
+      };
+
+      await expect(service.create(dto)).rejects.toBeInstanceOf(
+        ConflictException,
+      );
+
+      const calls = repo.existsByEmail.mock.calls;
+      expect(calls.length).toBe(1);
+      const [email] = calls[0];
+      expect(email).toBe('dup@example.com');
+    });
+
+    it('성공하면 UserPayload 반환 + 비밀번호 해시 저장', async () => {
+      repo.existsByEmail.mockResolvedValue(false);
+      const created = aDbUser({
+        id: 'u100',
+        email: 'new@example.com',
+        passwordHash: 'hashed:pw',
+        type: 'BUYER',
+      });
+      repo.create.mockResolvedValue(created);
+
+      const dto: CreateUserDto = {
+        email: 'new@example.com',
+        password: 'pw',
+        name: '새 유저',
+        type: 'BUYER',
+      };
+
+      const out: CreateReturn = await service.create(dto);
+
+      const createCalls = repo.create.mock.calls;
+      expect(createCalls.length).toBe(1);
+      const [arg] = createCalls[0] as [
+        {
+          name: string;
+          email: string;
+          passwordHash: string;
+          type: UserType;
+          image: string | null;
+        },
+      ];
+      expect(arg.email).toBe('new@example.com');
+      expect(arg.name).toBe('새 유저');
+      expect(arg.type).toBe('BUYER');
+      expect(arg.image).toBeNull();
+      expect(arg.passwordHash).toBe('hashed:pw');
+
+      expect(out.user).toEqual(payloadOf(created));
+    });
+  });
+
+  describe('getMe', () => {
+    it('유저 없으면 NotFoundException', async () => {
+      repo.findById.mockResolvedValue(null);
+
+      await expect(service.getMe('nope')).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    it('성공', async () => {
+      const u = aDbUser({ id: 'u1' });
+      repo.findById.mockResolvedValue(u);
+
+      const out: GetMeReturn = await service.getMe('u1');
+
+      const calls = repo.findById.mock.calls;
+      expect(calls.length).toBe(1);
+      const [id] = calls[0];
+      expect(id).toBe('u1');
+
+      expect(out).toEqual(payloadOf(u));
+    });
+  });
+
+  describe('updateMe', () => {
+    it('유저 없으면 NotFoundException', async () => {
+      repo.findById.mockResolvedValue(null);
+
+      const dto: UpdateUserDto = { currentPassword: 'cur' };
+      await expect(service.updateMe('u1', dto)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    it('현재 비밀번호 불일치면 UnauthorizedException', async () => {
+      const u = aDbUser({ passwordHash: 'hashed:DIFF' });
+      repo.findById.mockResolvedValue(u);
+
+      const dto: UpdateUserDto = { currentPassword: 'cur' };
+      await expect(service.updateMe('u1', dto)).rejects.toBeInstanceOf(
+        UnauthorizedException,
+      );
+
+      const calls = repo.findById.mock.calls;
+      expect(calls.length).toBe(1);
+    });
+
+    it('이름/이미지만 변경', async () => {
+      const u = aDbUser();
+      repo.findById.mockResolvedValue(u);
+
+      const updated = aDbUser({ name: '바뀜', image: 'img.png' });
+      repo.updateById.mockResolvedValue(updated);
+
+      const dto: UpdateUserDto = {
+        currentPassword: 'pw1234!',
+        name: '바뀜',
+        image: 'img.png',
+      };
+
+      const out: UpdateMeReturn = await service.updateMe('u1', dto);
+
+      const updCalls = repo.updateById.mock.calls;
+      expect(updCalls.length).toBe(1);
+      const [id, data] = updCalls[0];
+      expect(id).toBe('u1');
+      expect(data).toEqual(
+        expect.objectContaining({
+          name: '바뀜',
+          image: 'img.png',
+        }),
+      );
+
+      expect(data.passwordHash).toBeUndefined();
+
+      expect(out).toEqual(payloadOf(updated));
+    });
+
+    it('비밀번호 변경 포함', async () => {
+      const u = aDbUser();
+      repo.findById.mockResolvedValue(u);
+
+      const updated = aDbUser({ passwordHash: 'hashed:newPW' });
+      repo.updateById.mockResolvedValue(updated);
+
+      const dto: UpdateUserDto = {
+        currentPassword: 'pw1234!',
+        password: 'newPW',
+      };
+
+      const out: UpdateMeReturn = await service.updateMe('u1', dto);
+
+      const updCalls = repo.updateById.mock.calls;
+      expect(updCalls.length).toBe(1);
+      const [id, data] = updCalls[0];
+      expect(id).toBe('u1');
+      expect(data.passwordHash).toBe('hashed:newPW');
+
+      expect(out).toEqual(payloadOf(updated));
+    });
+  });
+
+  describe('getMyLikes', () => {
+    it('빈 배열 반환', async () => {
+      repo.findLikesByUserId.mockResolvedValue([]);
+
+      const out = await service.getMyLikes('u1');
+
+      const calls = repo.findLikesByUserId.mock.calls;
+      expect(calls.length).toBe(1);
+      const [uid] = calls[0];
+      expect(uid).toBe('u1');
+
+      expect(out).toEqual([]);
+    });
+  });
+
+  describe('deleteMe', () => {
+    it('유저 없음 → NotFoundException', async () => {
+      repo.findById.mockResolvedValue(null);
+
+      await expect(service.deleteMe('uX')).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    it('성공 → repo.deleteById 호출', async () => {
+      repo.findById.mockResolvedValue(aDbUser({ id: 'u1' }));
+      repo.deleteById.mockResolvedValue();
+
+      await service.deleteMe('u1');
+
+      const delCalls = repo.deleteById.mock.calls;
+      expect(delCalls.length).toBe(1);
+      const [uid] = delCalls[0];
+      expect(uid).toBe('u1');
+    });
+  });
+});

--- a/test/mocks/prisma.mock.ts
+++ b/test/mocks/prisma.mock.ts
@@ -1,0 +1,12 @@
+export const prismaMock = {
+  user: {
+    findUnique: jest.fn(),
+    findFirst: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+  },
+  pointTransaction: {
+    findMany: jest.fn(),
+    aggregate: jest.fn(),
+  },
+};

--- a/test/utils/mocks.ts
+++ b/test/utils/mocks.ts
@@ -1,0 +1,33 @@
+import { JwtService } from '@nestjs/jwt';
+
+export const createPrismaMock = () => ({
+  user: {
+    findUnique: jest.fn(),
+  },
+  session: {
+    create: jest.fn(),
+    findUnique: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    deleteMany: jest.fn(),
+  },
+});
+
+export const createJwtMock = () =>
+  ({
+    signAsync: jest.fn(() => 'signed.access'),
+  }) as unknown as jest.Mocked<JwtService>;
+
+export const aUser = (over: Partial<any> = {}) => ({
+  id: 'u1',
+  email: 'test@example.com',
+  name: '홍길동',
+  type: 'BUYER',
+  points: 0,
+  image: null,
+  gradeLevel: 'GREEN',
+  passwordHash: 'hashed:password123!',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...over,
+});


### PR DESCRIPTION
## 📝 요약
<!--- ex) 내용 설명 -->
- users, auth 모듈의 유닛 테스트를 추가했습니다.

## 📝 변경사항
<!--- ex) 변경사항 -->
- users.service.spec.ts, users.controller.spec.ts 추가
- auth.service.spec.ts, auth.controller.spec.ts 추가
- 테스트용 mock 유틸(mocks.ts, prisma.mock.ts) 추가

## 📝 추가설명
<!--- ex) 추가설명 -->
- Prisma 및 bcrypt, JwtService 의존성을 mock 처리하여 독립적인 유닛 테스트 환경을 구성했습니다.


## 🔗관련 이슈
- Closes #163 
<img width="603" height="220" alt="auth controller유닛테스트" src="https://github.com/user-attachments/assets/a404d113-b97a-47ce-9b7b-19d252e9f3b0" />
<img width="573" height="343" alt="auth service유닛테스트" src="https://github.com/user-attachments/assets/f8f5c84c-264c-4e2b-a7fb-64a995f1ac29" />
<img width="612" height="237" alt="users controller유닛테스트" src="https://github.com/user-attachments/assets/b80365ed-329c-41cb-bcf0-05837b22a413" />
<img width="589" height="425" alt="users service유닛테스트" src="https://github.com/user-attachments/assets/71361e8b-0daf-4cb7-b376-7dcaf7c0fd56" />

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).