### PR TITLE
test: 포인트, 등급 유닛 테스트 추가

### DIFF
--- a/src/grades/grade.service.spec.ts
+++ b/src/grades/grade.service.spec.ts
@@ -1,0 +1,125 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GradeService } from './grade.service';
+import { GradeRepository } from './grade.repository';
+import { GradeLevel } from '@prisma/client';
+import type { TxLike } from 'src/common/prisma-tx.type';
+import * as gradeUtil from './grade.util';
+
+describe('GradeService', () => {
+  let service: GradeService;
+
+  // Repository Mock
+  const tx: TxLike = { _tx: true } as unknown as TxLike;
+  const repoMock = {
+    prismaSvc: { _prisma: true },
+    sumLifetime: jest.fn<Promise<number>, [string, TxLike, string?]>(),
+    saveUserGrade: jest.fn<Promise<void>, [string, GradeLevel, TxLike]>(),
+  };
+
+  // --- Utils: 안전한 제네릭 타입으로 Spy 선언 (any 사용 금지) ---
+  const getEarnRateSpy: jest.SpyInstance<
+    ReturnType<typeof gradeUtil.getEarnRate>,
+    Parameters<typeof gradeUtil.getEarnRate>
+  > = jest.spyOn(gradeUtil, 'getEarnRate');
+
+  const getGradeByAmountSpy: jest.SpyInstance<
+    ReturnType<typeof gradeUtil.getGradeByAmount>,
+    Parameters<typeof gradeUtil.getGradeByAmount>
+  > = jest.spyOn(gradeUtil, 'getGradeByAmount');
+
+  const getNextGradeInfoSpy: jest.SpyInstance<
+    ReturnType<typeof gradeUtil.getNextGradeInfo>,
+    Parameters<typeof gradeUtil.getNextGradeInfo>
+  > = jest.spyOn(gradeUtil, 'getNextGradeInfo');
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GradeService,
+        { provide: GradeRepository, useValue: repoMock },
+      ],
+    }).compile();
+
+    service = module.get(GradeService);
+
+    // repo/spy 초기화 (재할당 없이 reset만)
+    jest.clearAllMocks();
+    getEarnRateSpy.mockReset();
+    getGradeByAmountSpy.mockReset();
+    getNextGradeInfoSpy.mockReset();
+  });
+
+  describe('getCurrentGrade', () => {
+    it('repo.prismaSvc 기본 tx를 사용하고, getGradeByAmount로 등급을 계산한다', async () => {
+      const userId = 'u1';
+      const lifetime = 123_456;
+
+      repoMock.sumLifetime.mockResolvedValueOnce(lifetime);
+      getGradeByAmountSpy.mockReturnValueOnce(GradeLevel.ORANGE);
+
+      const result = await service.getCurrentGrade(userId); // tx/제외주문 생략
+
+      expect(repoMock.sumLifetime).toHaveBeenCalledWith(
+        userId,
+        repoMock.prismaSvc, // 기본값 사용
+        undefined,
+      );
+      expect(getGradeByAmountSpy).toHaveBeenCalledWith(lifetime);
+      expect(result).toEqual({ lifetime, grade: GradeLevel.ORANGE });
+    });
+
+    it('명시한 tx와 excludeOrderId를 그대로 전달한다', async () => {
+      const userId = 'u2';
+      const excludeOrderId = 'order_999';
+      const lifetime = 50_000;
+
+      repoMock.sumLifetime.mockResolvedValueOnce(lifetime);
+      getGradeByAmountSpy.mockReturnValueOnce(GradeLevel.GREEN);
+
+      const result = await service.getCurrentGrade(userId, tx, excludeOrderId);
+
+      expect(repoMock.sumLifetime).toHaveBeenCalledWith(
+        userId,
+        tx,
+        excludeOrderId,
+      );
+      expect(result).toEqual({ lifetime, grade: GradeLevel.GREEN });
+    });
+  });
+
+  describe('getEarnRate', () => {
+    it('유틸 getEarnRate에 위임해 같은 값을 반환한다', () => {
+      getEarnRateSpy.mockReturnValueOnce(0.02);
+
+      const rate = service.getEarnRate(GradeLevel.GREEN);
+
+      expect(getEarnRateSpy).toHaveBeenCalledWith(GradeLevel.GREEN);
+      expect(rate).toBe(0.02);
+    });
+  });
+
+  describe('getNextGradeInfo', () => {
+    it('유틸 getNextGradeInfo에 위임해 같은 객체를 반환한다', () => {
+      getNextGradeInfoSpy.mockReturnValueOnce({
+        next: GradeLevel.ORANGE,
+        need: 50_000,
+      });
+
+      const info = service.getNextGradeInfo(10_000);
+
+      expect(getNextGradeInfoSpy).toHaveBeenCalledWith(10_000);
+      expect(info).toEqual({ next: GradeLevel.ORANGE, need: 50_000 });
+    });
+  });
+
+  describe('syncUserGrade', () => {
+    it('repo.saveUserGrade를 호출한다', async () => {
+      const userId = 'u3';
+      const level = GradeLevel.BLACK;
+
+      await service.syncUserGrade(userId, level, tx);
+
+      expect(repoMock.saveUserGrade).toHaveBeenCalledWith(userId, level, tx);
+    });
+  });
+});

--- a/src/grades/grade.service.spec.ts
+++ b/src/grades/grade.service.spec.ts
@@ -16,7 +16,6 @@ describe('GradeService', () => {
     saveUserGrade: jest.fn<Promise<void>, [string, GradeLevel, TxLike]>(),
   };
 
-  // --- Utils: 안전한 제네릭 타입으로 Spy 선언 (any 사용 금지) ---
   const getEarnRateSpy: jest.SpyInstance<
     ReturnType<typeof gradeUtil.getEarnRate>,
     Parameters<typeof gradeUtil.getEarnRate>
@@ -42,7 +41,6 @@ describe('GradeService', () => {
 
     service = module.get(GradeService);
 
-    // repo/spy 초기화 (재할당 없이 reset만)
     jest.clearAllMocks();
     getEarnRateSpy.mockReset();
     getGradeByAmountSpy.mockReset();
@@ -57,7 +55,7 @@ describe('GradeService', () => {
       repoMock.sumLifetime.mockResolvedValueOnce(lifetime);
       getGradeByAmountSpy.mockReturnValueOnce(GradeLevel.ORANGE);
 
-      const result = await service.getCurrentGrade(userId); // tx/제외주문 생략
+      const result = await service.getCurrentGrade(userId);
 
       expect(repoMock.sumLifetime).toHaveBeenCalledWith(
         userId,

--- a/src/grades/grade.util.spec.ts
+++ b/src/grades/grade.util.spec.ts
@@ -1,0 +1,136 @@
+import { GradeLevel } from '@prisma/client';
+import {
+  getEarnRate,
+  getGradeByAmount,
+  getNextGradeInfo,
+  resolveGradeByAmount,
+} from './grade.util';
+import { GRADE_MAP, GradePayload } from './grade.constants';
+
+describe('grade.util', () => {
+  // 등급을 minAmount 기준 오름차순 정렬 (상수 기반)
+  const orderedEntries: ReadonlyArray<[GradeLevel, GradePayload]> = (
+    Object.entries(GRADE_MAP) as [GradeLevel, GradePayload][]
+  )
+    .slice()
+    .sort((a, b) => a[1].minAmount - b[1].minAmount);
+
+  const orderedLevels: ReadonlyArray<GradeLevel> = orderedEntries.map(
+    ([lv]) => lv,
+  );
+
+  // 기대 등급 계산기: amount 이상인 마지막 등급
+  const expectedGradeByAmount = (amount: number): GradeLevel => {
+    let cur: GradeLevel = orderedEntries[0][0];
+    for (const [lv, payload] of orderedEntries) {
+      if (amount >= payload.minAmount) cur = lv;
+      else break;
+    }
+    return cur;
+  };
+
+  // 기대 다음 등급 계산기
+  const expectedNextInfo = (
+    totalAmount: number,
+  ): { next?: GradeLevel; need?: number } => {
+    // 현재 등급
+    const current = expectedGradeByAmount(totalAmount);
+    const idx = orderedLevels.findIndex((lv) => lv === current);
+    const nextTuple = orderedEntries[idx + 1];
+    if (!nextTuple) return {};
+    const [nextLevel, nextPayload] = nextTuple;
+    return {
+      next: nextLevel,
+      need: Math.max(0, nextPayload.minAmount - totalAmount),
+    };
+  };
+
+  describe('getEarnRate', () => {
+    it('모든 등급에 대해 GRADE_MAP의 earnRate와 동일하다', () => {
+      for (const [lv, payload] of orderedEntries) {
+        const rateFromUtil = getEarnRate(lv);
+        const rateFromConst = payload.earnRate;
+        expect(rateFromUtil).toBe(rateFromConst);
+      }
+    });
+  });
+
+  describe('getGradeByAmount', () => {
+    it('임계값 경계(직전/정확히/직후)에서 기대 등급을 반환한다', () => {
+      const samples: number[] = [];
+      for (const [, payload] of orderedEntries) {
+        const min = payload.minAmount;
+        samples.push(Math.max(0, min - 1)); // 직전
+        samples.push(min); // 정확히
+        samples.push(min + 1); // 직후
+      }
+
+      for (const amount of samples) {
+        const expected = expectedGradeByAmount(amount);
+        expect(getGradeByAmount(amount)).toBe(expected);
+      }
+    });
+
+    it('아주 큰 금액에서도 최상위 등급을 반환한다', () => {
+      const huge = Number.MAX_SAFE_INTEGER;
+      const top = orderedLevels[orderedLevels.length - 1];
+      expect(getGradeByAmount(huge)).toBe(top);
+    });
+
+    it('음수 금액은 최소 등급으로 처리한다(경계 방어)', () => {
+      const minLevel = orderedLevels[0];
+      expect(getGradeByAmount(-1)).toBe(minLevel);
+    });
+  });
+
+  describe('resolveGradeByAmount', () => {
+    it('level과 payload를 동시에 올바르게 반환한다', () => {
+      // 여러 샘플 금액으로 level/payload 일치성 확인
+      const samples = [0, 1, 50, 10_000, 123_456, Number.MAX_SAFE_INTEGER];
+      for (const amount of samples) {
+        const { level, payload } = resolveGradeByAmount(amount);
+        const expectedLevel = expectedGradeByAmount(amount);
+        expect(level).toBe(expectedLevel);
+        expect(payload).toBe(GRADE_MAP[level]); // 동일 객체(참조)여야 함
+      }
+    });
+  });
+
+  describe('getNextGradeInfo', () => {
+    it('임계값 경계(직전/정확히/직후)에서 다음 등급과 필요 금액을 정확히 계산한다', () => {
+      const samples: number[] = [];
+      for (const [, payload] of orderedEntries) {
+        const min = payload.minAmount;
+        samples.push(Math.max(0, min - 1));
+        samples.push(min);
+        samples.push(min + 1);
+      }
+
+      for (const lifetime of samples) {
+        const expected = expectedNextInfo(lifetime);
+        const info = getNextGradeInfo(lifetime);
+        expect(info).toEqual(expected);
+      }
+    });
+
+    it('최상위 등급 이상이면 next/need가 undefined이다', () => {
+      const top = orderedEntries[orderedEntries.length - 1];
+      const justTop = top[1].minAmount;
+      expect(getNextGradeInfo(justTop)).toEqual({});
+      expect(getNextGradeInfo(justTop + 123_456)).toEqual({});
+    });
+
+    it('음수 lifetime도 다음 등급 계산이 가능해야 한다', () => {
+      const negative = -100;
+      const expected = expectedNextInfo(negative);
+      const info = getNextGradeInfo(negative);
+      expect(info).toEqual(expected);
+      // sanity: next가 있으면 need는 next.minAmount - negative가 되어 양수
+      if (info.next) {
+        const nextMin = GRADE_MAP[info.next].minAmount;
+        expect(info.need).toBe(nextMin - negative);
+        expect(info.need! > 0).toBe(true);
+      }
+    });
+  });
+});

--- a/src/grades/grade.util.spec.ts
+++ b/src/grades/grade.util.spec.ts
@@ -8,7 +8,6 @@ import {
 import { GRADE_MAP, GradePayload } from './grade.constants';
 
 describe('grade.util', () => {
-  // 등급을 minAmount 기준 오름차순 정렬 (상수 기반)
   const orderedEntries: ReadonlyArray<[GradeLevel, GradePayload]> = (
     Object.entries(GRADE_MAP) as [GradeLevel, GradePayload][]
   )
@@ -19,7 +18,7 @@ describe('grade.util', () => {
     ([lv]) => lv,
   );
 
-  // 기대 등급 계산기: amount 이상인 마지막 등급
+  // 기대 등급 계산
   const expectedGradeByAmount = (amount: number): GradeLevel => {
     let cur: GradeLevel = orderedEntries[0][0];
     for (const [lv, payload] of orderedEntries) {
@@ -29,7 +28,7 @@ describe('grade.util', () => {
     return cur;
   };
 
-  // 기대 다음 등급 계산기
+  // 기대 다음 등급 계산
   const expectedNextInfo = (
     totalAmount: number,
   ): { next?: GradeLevel; need?: number } => {
@@ -85,13 +84,12 @@ describe('grade.util', () => {
 
   describe('resolveGradeByAmount', () => {
     it('level과 payload를 동시에 올바르게 반환한다', () => {
-      // 여러 샘플 금액으로 level/payload 일치성 확인
       const samples = [0, 1, 50, 10_000, 123_456, Number.MAX_SAFE_INTEGER];
       for (const amount of samples) {
         const { level, payload } = resolveGradeByAmount(amount);
         const expectedLevel = expectedGradeByAmount(amount);
         expect(level).toBe(expectedLevel);
-        expect(payload).toBe(GRADE_MAP[level]); // 동일 객체(참조)여야 함
+        expect(payload).toBe(GRADE_MAP[level]);
       }
     });
   });
@@ -125,7 +123,7 @@ describe('grade.util', () => {
       const expected = expectedNextInfo(negative);
       const info = getNextGradeInfo(negative);
       expect(info).toEqual(expected);
-      // sanity: next가 있으면 need는 next.minAmount - negative가 되어 양수
+
       if (info.next) {
         const nextMin = GRADE_MAP[info.next].minAmount;
         expect(info.need).toBe(nextMin - negative);

--- a/src/points/points.controller.spec.ts
+++ b/src/points/points.controller.spec.ts
@@ -6,7 +6,6 @@ import { GradeLevel } from '@prisma/client';
 describe('PointsController', () => {
   let controller: PointsController;
 
-  // 모의 서비스 함수 (unbound-method 회피를 위해 변수로 보관)
   const getMyPointSummaryMock = jest.fn();
 
   beforeEach(async () => {

--- a/src/points/points.controller.spec.ts
+++ b/src/points/points.controller.spec.ts
@@ -1,0 +1,49 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PointsController } from './points.controller';
+import { PointsService } from './points.service';
+import { GradeLevel } from '@prisma/client';
+
+describe('PointsController', () => {
+  let controller: PointsController;
+
+  // 모의 서비스 함수 (unbound-method 회피를 위해 변수로 보관)
+  const getMyPointSummaryMock = jest.fn();
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PointsController],
+      providers: [
+        {
+          provide: PointsService,
+          useValue: {
+            getMyPointSummary: getMyPointSummaryMock,
+          } satisfies Partial<PointsService>,
+        },
+      ],
+    }).compile();
+
+    controller = module.get(PointsController);
+    getMyPointSummaryMock.mockReset();
+  });
+
+  it('GET /api/users/me/points: service.getMyPointSummary를 호출하고 결과를 반환한다', async () => {
+    const userId = 'user_123';
+    const req: { user: { userId: string } } = { user: { userId } };
+
+    const summary: Awaited<ReturnType<PointsService['getMyPointSummary']>> = {
+      points: 1000,
+      gradeLevel: GradeLevel.GREEN,
+      lifetimePurchase: 50000,
+      earnRate: 0.01,
+      nextGrade: GradeLevel.ORANGE,
+      needToNext: 50000,
+    };
+
+    getMyPointSummaryMock.mockResolvedValue(summary);
+
+    const result = await controller.getMyPoints(req);
+
+    expect(getMyPointSummaryMock).toHaveBeenCalledWith(userId);
+    expect(result).toEqual(summary);
+  });
+});

--- a/src/points/points.service.spec.ts
+++ b/src/points/points.service.spec.ts
@@ -1,0 +1,295 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { PointsService } from './points.service';
+import { PointsRepository } from './points.repository';
+import { GradeService } from 'src/grades/grade.service';
+import { OrderStatus } from '@prisma/client';
+import { REASON } from './points.types';
+
+describe('PointsService', () => {
+  let service: PointsService;
+  let repo: {
+    prismaSvc: { $transaction: <T>(fn: (tx: any) => Promise<T>) => Promise<T> };
+    getUserBasic: jest.Mock;
+    hasPointLog: jest.Mock;
+    decUserPointsIfEnough: jest.Mock;
+    createPointLog: jest.Mock;
+    getOrder: jest.Mock;
+    incUserPoints: jest.Mock;
+    getEarnedDelta: jest.Mock;
+  };
+  let grade: {
+    getCurrentGrade: jest.Mock;
+    getEarnRate: jest.Mock;
+    getNextGradeInfo: jest.Mock;
+    syncUserGrade: jest.Mock;
+  };
+
+  // 간단한 트랜잭션 목: 콜백을 즉시 실행하고 tx 객체를 전달
+  const tx = { _tx: true };
+  const runTx = async <T>(fn: (t: any) => Promise<T>) => fn(tx);
+
+  beforeEach(async () => {
+    repo = {
+      prismaSvc: { $transaction: jest.fn(runTx) },
+      getUserBasic: jest.fn(),
+      hasPointLog: jest.fn(),
+      decUserPointsIfEnough: jest.fn(),
+      createPointLog: jest.fn(),
+      getOrder: jest.fn(),
+      incUserPoints: jest.fn(),
+      getEarnedDelta: jest.fn(),
+    };
+
+    grade = {
+      getCurrentGrade: jest.fn(),
+      getEarnRate: jest.fn(),
+      getNextGradeInfo: jest.fn(),
+      syncUserGrade: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PointsService,
+        { provide: PointsRepository, useValue: repo },
+        { provide: GradeService, useValue: grade },
+      ],
+    }).compile();
+
+    service = module.get(PointsService);
+  });
+
+  describe('getMyPointSummary', () => {
+    it('유저가 없으면 BadRequestException', async () => {
+      repo.getUserBasic.mockResolvedValue(null);
+      await expect(service.getMyPointSummary('nope')).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+    });
+
+    it('유저/등급/다음등급 정보를 묶어서 반환', async () => {
+      repo.getUserBasic.mockResolvedValue({ id: 'u1', points: 1234 });
+      grade.getCurrentGrade.mockResolvedValue({
+        lifetime: 50000,
+        grade: 'GREEN',
+      });
+      grade.getEarnRate.mockReturnValue(0.01);
+      grade.getNextGradeInfo.mockReturnValue({ next: 'ORANGE', need: 50000 });
+
+      const res = await service.getMyPointSummary('u1');
+      expect(res).toEqual({
+        points: 1234,
+        gradeLevel: 'GREEN',
+        lifetimePurchase: 50000,
+        earnRate: 0.01,
+        nextGrade: 'ORANGE',
+        needToNext: 50000,
+      });
+      expect(repo.getUserBasic).toHaveBeenCalledWith('u1');
+      expect(grade.getCurrentGrade).toHaveBeenCalledWith('u1');
+      expect(grade.getEarnRate).toHaveBeenCalledWith('GREEN');
+      expect(grade.getNextGradeInfo).toHaveBeenCalledWith(50000);
+    });
+  });
+
+  describe('spendPointsForOrder', () => {
+    it('amount가 0 이하이면 아무 것도 하지 않음', async () => {
+      await service.spendPointsForOrder('u1', 'o1', 0);
+      expect(repo.prismaSvc.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('이미 SPEND_ORDER 로그가 있으면 스킵', async () => {
+      repo.hasPointLog.mockResolvedValue(true);
+      await service.spendPointsForOrder('u1', 'o1', 100);
+      expect(repo.hasPointLog).toHaveBeenCalledWith(
+        'u1',
+        'o1',
+        REASON.SPEND_ORDER,
+        tx,
+      );
+      expect(repo.decUserPointsIfEnough).not.toHaveBeenCalled();
+    });
+
+    it('포인트 부족하면 BadRequestException', async () => {
+      repo.hasPointLog.mockResolvedValue(false);
+      repo.decUserPointsIfEnough.mockResolvedValue(false);
+
+      await expect(
+        service.spendPointsForOrder('u1', 'o1', 1000),
+      ).rejects.toBeInstanceOf(BadRequestException);
+
+      expect(repo.decUserPointsIfEnough).toHaveBeenCalledWith('u1', 1000, tx);
+      expect(repo.createPointLog).not.toHaveBeenCalled();
+    });
+
+    it('성공 시 차감 및 로그 생성', async () => {
+      repo.hasPointLog.mockResolvedValue(false);
+      repo.decUserPointsIfEnough.mockResolvedValue(true);
+
+      await service.spendPointsForOrder('u1', 'o1', 300);
+
+      expect(repo.decUserPointsIfEnough).toHaveBeenCalledWith('u1', 300, tx);
+      expect(repo.createPointLog).toHaveBeenCalledWith(
+        'u1',
+        'o1',
+        -300,
+        REASON.SPEND_ORDER,
+        tx,
+      );
+    });
+  });
+
+  describe('earnPointsOnPaidOrder', () => {
+    it('주문이 없으면 BadRequestException', async () => {
+      repo.getOrder.mockResolvedValue(null);
+      await expect(service.earnPointsOnPaidOrder('oX')).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+    });
+
+    it('주문 상태가 COMPLETEDPAYMENT가 아니면 아무 것도 하지 않음', async () => {
+      repo.getOrder.mockResolvedValue({
+        id: 'o1',
+        userId: 'u1',
+        status: OrderStatus.PROCESSING, // 존재하는 비-완료 상태로 변경
+        totalPrice: 10000,
+      });
+
+      await service.earnPointsOnPaidOrder('o1');
+      expect(repo.hasPointLog).not.toHaveBeenCalled();
+      expect(repo.incUserPoints).not.toHaveBeenCalled();
+      expect(grade.syncUserGrade).not.toHaveBeenCalled();
+    });
+
+    it('이미 적립 로그가 있으면 스킵', async () => {
+      repo.getOrder.mockResolvedValue({
+        id: 'o1',
+        userId: 'u1',
+        status: OrderStatus.COMPLETEDPAYMENT,
+        totalPrice: 10000,
+      });
+      repo.hasPointLog.mockResolvedValue(true);
+
+      await service.earnPointsOnPaidOrder('o1');
+      expect(repo.incUserPoints).not.toHaveBeenCalled();
+      expect(repo.createPointLog).not.toHaveBeenCalled();
+    });
+
+    it('적립률로 earn을 계산하여 적립/로그 및 등급 동기화', async () => {
+      repo.getOrder.mockResolvedValue({
+        id: 'o1',
+        userId: 'u1',
+        status: OrderStatus.COMPLETEDPAYMENT,
+        totalPrice: 12345, // earn = floor(12345 * 0.02) = 246
+      });
+      repo.hasPointLog.mockResolvedValue(false);
+      grade.getCurrentGrade
+        // 첫 번째: "지금 처리 중인 주문 제외" 시나리오
+        .mockResolvedValueOnce({ grade: 'GREEN' })
+        // 두 번째: 적립 후 표시용 등급 캐시 동기화용
+        .mockResolvedValueOnce({ grade: 'ORANGE' });
+
+      grade.getEarnRate.mockReturnValue(0.02);
+
+      await service.earnPointsOnPaidOrder('o1');
+
+      expect(grade.getCurrentGrade).toHaveBeenNthCalledWith(1, 'u1', tx, 'o1');
+      expect(grade.getEarnRate).toHaveBeenCalledWith('GREEN');
+      expect(repo.incUserPoints).toHaveBeenCalledWith('u1', 246, tx);
+      expect(repo.createPointLog).toHaveBeenCalledWith(
+        'u1',
+        'o1',
+        246,
+        REASON.EARN_PURCHASE,
+        tx,
+      );
+      expect(grade.syncUserGrade).toHaveBeenCalledWith('u1', 'ORANGE', tx);
+    });
+
+    it('earn이 0 이하면 적립/로그 생략하고 등급 동기화만 수행', async () => {
+      repo.getOrder.mockResolvedValue({
+        id: 'o1',
+        userId: 'u1',
+        status: OrderStatus.COMPLETEDPAYMENT,
+        totalPrice: -100, // max(0, total) → 0
+      });
+      repo.hasPointLog.mockResolvedValue(false);
+      grade.getCurrentGrade
+        .mockResolvedValueOnce({ grade: 'GREEN' })
+        .mockResolvedValueOnce({ grade: 'GREEN' });
+      grade.getEarnRate.mockReturnValue(0.01);
+
+      await service.earnPointsOnPaidOrder('o1');
+
+      expect(repo.incUserPoints).not.toHaveBeenCalled();
+      expect(repo.createPointLog).not.toHaveBeenCalled();
+      expect(grade.syncUserGrade).toHaveBeenCalledWith('u1', 'GREEN', tx);
+    });
+  });
+
+  describe('revertOnCancel', () => {
+    it('주문이 없으면 조용히 종료', async () => {
+      repo.getOrder.mockResolvedValue(null);
+      await service.revertOnCancel('oX');
+      expect(repo.hasPointLog).not.toHaveBeenCalled();
+      expect(grade.syncUserGrade).not.toHaveBeenCalled();
+    });
+
+    it('이미 REVERT_CANCEL 로그가 있으면 회수는 건너뛰고 등급 동기화만', async () => {
+      repo.getOrder.mockResolvedValue({ id: 'o1', userId: 'u1' });
+      repo.hasPointLog.mockResolvedValue(true);
+      grade.getCurrentGrade.mockResolvedValue({ grade: 'GREEN' });
+
+      await service.revertOnCancel('o1');
+
+      expect(repo.getEarnedDelta).not.toHaveBeenCalled();
+      expect(grade.syncUserGrade).toHaveBeenCalledWith('u1', 'GREEN', tx);
+    });
+
+    it('적립 회수 대상이 있으면 차감 및 회수 로그 생성', async () => {
+      repo.getOrder.mockResolvedValue({ id: 'o1', userId: 'u1' });
+      repo.hasPointLog.mockResolvedValue(false);
+      repo.getEarnedDelta.mockResolvedValue(150);
+      repo.decUserPointsIfEnough.mockResolvedValue(true);
+      grade.getCurrentGrade.mockResolvedValue({ grade: 'ORANGE' });
+
+      await service.revertOnCancel('o1');
+
+      expect(repo.decUserPointsIfEnough).toHaveBeenCalledWith('u1', 150, tx);
+      expect(repo.createPointLog).toHaveBeenCalledWith(
+        'u1',
+        'o1',
+        -150,
+        REASON.REVERT_CANCEL,
+        tx,
+      );
+      expect(grade.syncUserGrade).toHaveBeenCalledWith('u1', 'ORANGE', tx);
+    });
+
+    it('회수할 포인트가 부족하면 BadRequestException', async () => {
+      repo.getOrder.mockResolvedValue({ id: 'o1', userId: 'u1' });
+      repo.hasPointLog.mockResolvedValue(false);
+      repo.getEarnedDelta.mockResolvedValue(200);
+      repo.decUserPointsIfEnough.mockResolvedValue(false);
+
+      await expect(service.revertOnCancel('o1')).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+
+      expect(repo.createPointLog).not.toHaveBeenCalled();
+    });
+
+    it('earnedDelta가 0 이하이면 회수 스킵하고 등급만 동기화', async () => {
+      repo.getOrder.mockResolvedValue({ id: 'o1', userId: 'u1' });
+      repo.hasPointLog.mockResolvedValue(false);
+      repo.getEarnedDelta.mockResolvedValue(0);
+      grade.getCurrentGrade.mockResolvedValue({ grade: 'GREEN' });
+
+      await service.revertOnCancel('o1');
+
+      expect(repo.decUserPointsIfEnough).not.toHaveBeenCalled();
+      expect(repo.createPointLog).not.toHaveBeenCalled();
+      expect(grade.syncUserGrade).toHaveBeenCalledWith('u1', 'GREEN', tx);
+    });
+  });
+});

--- a/src/points/points.service.spec.ts
+++ b/src/points/points.service.spec.ts
@@ -25,7 +25,7 @@ describe('PointsService', () => {
     syncUserGrade: jest.Mock;
   };
 
-  // 간단한 트랜잭션 목: 콜백을 즉시 실행하고 tx 객체를 전달
+  // 트랜잭션 시뮬레이션
   const tx = { _tx: true };
   const runTx = async <T>(fn: (t: any) => Promise<T>) => fn(tx);
 
@@ -151,7 +151,7 @@ describe('PointsService', () => {
       repo.getOrder.mockResolvedValue({
         id: 'o1',
         userId: 'u1',
-        status: OrderStatus.PROCESSING, // 존재하는 비-완료 상태로 변경
+        status: OrderStatus.PROCESSING,
         totalPrice: 10000,
       });
 
@@ -184,9 +184,9 @@ describe('PointsService', () => {
       });
       repo.hasPointLog.mockResolvedValue(false);
       grade.getCurrentGrade
-        // 첫 번째: "지금 처리 중인 주문 제외" 시나리오
+        // 지금 처리 중인 주문 제외
         .mockResolvedValueOnce({ grade: 'GREEN' })
-        // 두 번째: 적립 후 표시용 등급 캐시 동기화용
+        // 적립 후 표시용 등급 캐시 동기화용
         .mockResolvedValueOnce({ grade: 'ORANGE' });
 
       grade.getEarnRate.mockReturnValue(0.02);
@@ -211,7 +211,7 @@ describe('PointsService', () => {
         id: 'o1',
         userId: 'u1',
         status: OrderStatus.COMPLETEDPAYMENT,
-        totalPrice: -100, // max(0, total) → 0
+        totalPrice: -100,
       });
       repo.hasPointLog.mockResolvedValue(false);
       grade.getCurrentGrade


### PR DESCRIPTION
## 📝 요약
<!--- ex) 내용 설명 -->
- 포인트 및 등급 관련 유닛 테스트를 추가했습니다.

## 📝 변경사항
<!--- ex) 변경사항 -->
- points.controller.spec.ts, points.service.spec.ts 추가
- grade.service.spec.ts, grade.util.spec.ts 추가

## 📝 추가설명
<!--- ex) 추가설명 -->
<img width="662" height="170" alt="points controller유닛테스트" src="https://github.com/user-attachments/assets/863cf970-8371-4daa-b538-0d197df44659" />
<img width="603" height="491" alt="points service유닛테스트" src="https://github.com/user-attachments/assets/3707b96e-6d37-4497-baba-2e078a8c29e2" />
<img width="611" height="306" alt="grade service유닛테스트" src="https://github.com/user-attachments/assets/c7213ba0-7a49-4619-9925-1159ef4b24ab" />
<img width="638" height="359" alt="grade util유닛테스트" src="https://github.com/user-attachments/assets/978bec74-f342-4213-b119-a931b21171d7" />


## 🔗관련 이슈
- Closes #165 

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).