### PR TITLE
chore: auth, users, points Swagger 문서 추가

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -19,7 +19,15 @@ import {
   setRefreshCookie,
   clearRefreshCookie,
 } from './cookie.util';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBody,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
 
+@ApiTags('Auth')
 @Controller('api/auth')
 export class AuthController {
   constructor(private readonly auth: AuthService) {}
@@ -27,6 +35,26 @@ export class AuthController {
   // 로그인: POST /api/auth/login
   @Post('login')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: '로그인',
+    description: '이메일과 비밀번호로 로그인합니다.',
+  })
+  @ApiBody({ type: LoginDto })
+  @ApiResponse({
+    status: 200,
+    description: '로그인 성공',
+    schema: {
+      example: {
+        user: {
+          id: 'user_123',
+          email: 'test@example.com',
+          role: 'BUYER',
+        },
+        accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+      },
+    },
+  })
+  @ApiResponse({ status: 400, description: '잘못된 요청 또는 비밀번호 오류' })
   async login(
     @Body() dto: LoginDto,
     @Res({ passthrough: true }) res: Response,
@@ -42,6 +70,19 @@ export class AuthController {
   // 토큰 재발급: POST /api/auth/refresh
   @Post('refresh')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: '토큰 재발급',
+    description: 'Refresh Token 쿠키를 사용하여 Access Token을 재발급합니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '재발급 성공',
+    schema: { example: { accessToken: 'new-access-token...' } },
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Refresh Token이 없거나 유효하지 않음',
+  })
   async refresh(
     @Req() req: RequestWithCookies,
     @Res({ passthrough: true }) res: Response,
@@ -58,6 +99,17 @@ export class AuthController {
   @UseGuards(AuthGuard('jwt'))
   @Post('logout')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: '로그아웃',
+    description:
+      '현재 로그인한 사용자를 로그아웃하고 Refresh Token 쿠키를 삭제합니다.',
+  })
+  @ApiBearerAuth() // JWT 인증 필요 표시
+  @ApiResponse({
+    status: 200,
+    description: '로그아웃 성공',
+    schema: { example: { message: '성공적으로 로그아웃되었습니다.' } },
+  })
   async logout(
     @Req() req: RequestWithUser,
     @Res({ passthrough: true }) res: Response,

--- a/src/auth/dto/login.dto.ts
+++ b/src/auth/dto/login.dto.ts
@@ -1,10 +1,19 @@
 import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class LoginDto {
+  @ApiProperty({
+    example: 'user@example.com',
+    description: '로그인할 사용자 이메일 주소',
+  })
   @IsEmail()
   @IsNotEmpty()
   email!: string;
 
+  @ApiProperty({
+    example: 'securePassword123!',
+    description: '사용자 비밀번호',
+  })
   @IsString()
   @IsNotEmpty()
   password!: string;

--- a/src/points/points.controller.ts
+++ b/src/points/points.controller.ts
@@ -1,13 +1,17 @@
 import { Controller, Get, UseGuards, Req } from '@nestjs/common';
 import { JwtAuthGuard } from 'src/auth/jwt.guard';
 import { PointsService } from './points.service';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 
+@ApiTags('Points')
+@ApiBearerAuth()
 @Controller('api/users/me')
 export class PointsController {
   constructor(private readonly points: PointsService) {}
 
   @UseGuards(JwtAuthGuard)
   @Get('points')
+  @ApiOperation({ summary: '내 포인트 및 등급 요약 조회' })
   getMyPoints(@Req() req: { user: { userId: string } }) {
     return this.points.getMyPointSummary(req.user.userId);
   }

--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -7,20 +7,39 @@ import {
   MinLength,
 } from 'class-validator';
 import { UserType } from '@prisma/client';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreateUserDto {
+  @ApiProperty({
+    example: '홍길동',
+    description: '사용자 이름',
+  })
   @IsString()
   @IsNotEmpty()
   name!: string;
 
+  @ApiProperty({
+    example: 'test@example.com',
+    description: '사용자 이메일 주소',
+  })
   @IsString()
   @IsEmail()
   email!: string;
 
+  @ApiProperty({
+    example: 'password1234',
+    description: '비밀번호 (최소 8자 이상)',
+    minLength: 8,
+  })
   @IsString()
   @MinLength(8)
   password!: string;
 
+  @ApiPropertyOptional({
+    example: 'BUYER',
+    description: '사용자 타입 (BUYER 또는 SELLER)',
+    enum: UserType,
+  })
   @IsOptional()
   @IsEnum(UserType, { message: 'type must be BUYER or SELLER' })
   type!: UserType; // 'BUYER' | 'SELLER'

--- a/src/users/dto/update-user.dto.ts
+++ b/src/users/dto/update-user.dto.ts
@@ -1,18 +1,35 @@
 import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class UpdateUserDto {
+  @ApiPropertyOptional({
+    example: '수정된이름',
+    description: '새로운 이름',
+  })
   @IsString()
   @IsOptional()
   name?: string;
 
+  @ApiPropertyOptional({
+    example: 'newPassword123!',
+    description: '새 비밀번호',
+  })
   @IsString()
   @IsOptional()
   password?: string;
 
+  @ApiProperty({
+    example: 'currentPassword123!',
+    description: '현재 비밀번호 (필수)',
+  })
   @IsString()
   @IsNotEmpty()
   currentPassword!: string;
 
+  @ApiPropertyOptional({
+    example: 'https://example.com/profile.jpg',
+    description: '프로필 이미지 URL',
+  })
   @IsString()
   @IsOptional()
   image?: string;

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -17,7 +17,15 @@ import type { UserPayload } from './users.mapper';
 import type { AuthUser } from '../auth/auth.types';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { JwtAuthGuard } from '../auth/jwt.guard';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiBody,
+} from '@nestjs/swagger';
 
+@ApiTags('Users')
 @Controller('api/users')
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
@@ -25,6 +33,32 @@ export class UsersController {
   // 회원가입: POST /api/users
   @Post()
   @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: '회원가입',
+    description: '새로운 사용자를 등록합니다.',
+  })
+  @ApiBody({ type: CreateUserDto })
+  @ApiResponse({
+    status: 201,
+    description: '회원가입 성공',
+    schema: {
+      example: {
+        user: {
+          id: 'u123',
+          email: 'test@example.com',
+          name: '홍길동',
+          type: 'BUYER',
+          points: '0',
+          image: null,
+          grade: { id: 'GREEN', name: 'GREEN', rate: 0.01, minAmount: 0 },
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 400,
+    description: '중복 이메일 또는 유효성 검증 실패',
+  })
   signup(@Body() dto: CreateUserDto): Promise<{ user: UserPayload }> {
     return this.usersService.create(dto);
   }
@@ -32,6 +66,27 @@ export class UsersController {
   // 내 정보 조회: GET /api/users/me
   @UseGuards(JwtAuthGuard)
   @Get('me')
+  @ApiOperation({
+    summary: '내 정보 조회',
+    description: '현재 로그인한 사용자의 정보를 조회합니다.',
+  })
+  @ApiBearerAuth()
+  @ApiResponse({
+    status: 200,
+    description: '내 정보 조회 성공',
+    schema: {
+      example: {
+        id: 'u1',
+        email: 'test@example.com',
+        name: '홍길동',
+        type: 'BUYER',
+        points: 1000,
+        image: null,
+        grade: { id: 'GREEN', name: 'GREEN', rate: 0.01, minAmount: 0 },
+      },
+    },
+  })
+  @ApiResponse({ status: 401, description: '인증 실패' })
   getMe(@CurrentUser() user: AuthUser): Promise<UserPayload> {
     return this.usersService.getMe(user.userId);
   }
@@ -39,6 +94,28 @@ export class UsersController {
   // 내 정보 수정 (현재 비밀번호 필수): PATCH /api/users/me
   @UseGuards(JwtAuthGuard)
   @Patch('me')
+  @ApiOperation({
+    summary: '내 정보 수정',
+    description: '로그인한 사용자의 정보를 수정합니다.',
+  })
+  @ApiBearerAuth()
+  @ApiBody({ type: UpdateUserDto })
+  @ApiResponse({
+    status: 200,
+    description: '정보 수정 성공',
+    schema: {
+      example: {
+        id: 'u1',
+        email: 'test@example.com',
+        name: '수정된이름',
+        type: 'BUYER',
+        points: 1000,
+        image: null,
+      },
+    },
+  })
+  @ApiResponse({ status: 400, description: '유효성/현재 비밀번호 오류' })
+  @ApiResponse({ status: 401, description: '인증 실패' })
   updateMe(
     @CurrentUser() user: AuthUser,
     @Body() dto: UpdateUserDto,
@@ -49,6 +126,32 @@ export class UsersController {
   // 내 관심 스토어 조회: GET /api/users/me/likes
   @UseGuards(JwtAuthGuard)
   @Get('me/likes')
+  @ApiOperation({
+    summary: '관심 스토어 조회',
+    description: '내가 찜한 스토어 목록을 조회합니다.',
+  })
+  @ApiBearerAuth()
+  @ApiResponse({
+    status: 200,
+    description: '관심 스토어 목록 조회 성공',
+    schema: {
+      example: [
+        {
+          id: 'store_1',
+          name: '코디잇 스토어',
+          ownerId: 'u9',
+          likedAt: '2025-10-17T10:00:00Z',
+        },
+        {
+          id: 'store_2',
+          name: '브리아아 패션샵',
+          ownerId: 'u3',
+          likedAt: '2025-10-17T10:05:00Z',
+        },
+      ],
+    },
+  })
+  @ApiResponse({ status: 401, description: '인증 실패' })
   getMyLikes(@CurrentUser() user: AuthUser) {
     return this.usersService.getMyLikes(user.userId);
   }
@@ -57,6 +160,17 @@ export class UsersController {
   @UseGuards(JwtAuthGuard)
   @Delete('delete')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: '회원 탈퇴',
+    description: '현재 로그인한 사용자의 계정을 삭제합니다.',
+  })
+  @ApiBearerAuth()
+  @ApiResponse({
+    status: 200,
+    description: '회원 탈퇴 성공',
+    schema: { example: { message: '회원 탈퇴가 완료되었습니다.' } },
+  })
+  @ApiResponse({ status: 401, description: '인증 실패' })
   async deleteMe(@CurrentUser() user: AuthUser): Promise<{ message: string }> {
     await this.usersService.deleteMe(user.userId);
     return { message: '회원 탈퇴가 완료되었습니다.' };

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -144,7 +144,7 @@ export class UsersController {
         },
         {
           id: 'store_2',
-          name: '브리아아 패션샵',
+          name: '브리아 패션샵',
           ownerId: 'u3',
           likedAt: '2025-10-17T10:05:00Z',
         },


### PR DESCRIPTION
## 📝 요약
<!--- ex) 내용 설명 -->
- auth, users, points API에 Swagger 문서화 기능을 추가했습니다.

## 📝 변경사항
<!--- ex) 변경사항 -->
- 각 컨트롤러(auth, users, points)에 Swagger 데코레이터(@ApiTags, @ApiOperation, @ApiResponse) 추가
- 요청/응답 DTO에 @ApiProperty 적용

## 📝 추가설명
<!--- ex) 추가설명 -->
- Swagger UI에서 요청/응답 스키마를 확인할 수 있습니다.

## 🔗관련 이슈
- Closes #175 

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).