### PR TITLE
fix: cookie-parser 전역 미들웨어 추가 및  쿠키 파싱 문제 해결

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import type { Request, Response, NextFunction } from 'express';
+import cookieParser from 'cookie-parser';
 
 function buildCorsOrigin() {
   const list = (process.env.CORS_ORIGINS ?? '')
@@ -33,6 +34,8 @@ async function bootstrap() {
     allowedHeaders: ['Content-Type', 'Authorization', 'X-Requested-With'],
     optionsSuccessStatus: 204,
   });
+
+  app.use(cookieParser());
 
   // '/users', '/auth'로 들어오는 요청을 '/api/users', '/api/auth'로 리다이렉트
   app.use((req: Request, _res: Response, next: NextFunction) => {


### PR DESCRIPTION
## 📝 요약
<!--- ex) 내용 설명 -->
- cookie-parser 전역 미들웨어를 추가하여 쿠키 기반 인증 로직(req.cookies)이 정상 작동하도록 수정했습니다.

## 📝 변경사항
<!--- ex) 변경사항 -->
- main.ts에 import cookieParser from 'cookie-parser'; 추가
- app.use(cookieParser()); 전역 등록
- Refresh Token 재발급 시 쿠키 파싱 오류 해결

## 📝 추가설명
<!--- ex) 추가설명 -->
- 쿠키 파싱 및 인증 흐름이 정상화되었습니다.
<img width="652" height="755" alt="리프레쉬토큰n" src="https://github.com/user-attachments/assets/8f44d663-10c1-4e2d-b651-473d3e9ae9f5" />

## 🔗관련 이슈
- Closes #192 

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).