### PR TITLE
refactor: CORS 설정 로직 정리

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,27 +1,48 @@
-import { NestFactory } from '@nestjs/core';
+import cookieParser from 'cookie-parser';
 import { AppModule } from './app.module';
+import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
-import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { setupSentry } from './common/logger/sentry.config';
 import { SentryGlobalFilter } from './common/logger/sentry.filter';
-import type { Request, Response, NextFunction } from 'express';
-import cookieParser from 'cookie-parser';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
-function buildCorsOrigin() {
-  const list = (process.env.CORS_ORIGINS ?? '')
+type Matcher = string | RegExp;
+
+function buildCorsOrigin(): (
+  origin: string | undefined,
+  cb: (err: Error | null, allow?: boolean) => void,
+) => void {
+  const raw = (process.env.CORS_ORIGINS ?? '')
     .split(',')
-    .map((s) => s.trim())
+    .map((origin) => origin.trim())
     .filter(Boolean);
 
-  if (list.length === 0) list.push('http://localhost:3001');
+  // 로컬
+  if (raw.length === 0) raw.push('http://localhost:3001');
 
-  // 동적 origin 검사 콜백 함수 반환
-  return (
-    origin: string | undefined,
-    cb: (err: Error | null, allow?: boolean) => void,
-  ) => {
+  // 와일드카드
+  const allowList: Matcher[] = raw.map((originPattern) => {
+    if (originPattern.startsWith('*.')) {
+      const host = originPattern.slice(2).replace(/\./g, '\\.');
+      return new RegExp(
+        `^https?:\\/\\/([a-z0-9-]+\\.)*${host}(?::\\d+)?$`,
+        'i',
+      );
+    }
+    return originPattern;
+  });
+
+  const isAllowed = (origin: string): boolean => {
+    return allowList.some((rule) => {
+      if (rule instanceof RegExp) return rule.test(origin);
+      return rule === origin;
+    });
+  };
+
+  return (origin, cb) => {
     if (!origin) return cb(null, true);
-    cb(null, list.includes(origin));
+    const ok = isAllowed(origin);
+    return cb(ok ? null : new Error(`Not allowed by CORS: ${origin}`), ok);
   };
 }
 
@@ -32,9 +53,6 @@ async function bootstrap() {
     logger: ['log', 'error', 'warn', 'debug', 'verbose'],
   });
 
-  app.useGlobalFilters(new SentryGlobalFilter());
-
-  // CORS 전역 설정 (개발/배포 공통)
   app.enableCors({
     origin: buildCorsOrigin(),
     credentials: true,
@@ -45,16 +63,8 @@ async function bootstrap() {
 
   app.use(cookieParser());
 
-  // '/users', '/auth'로 들어오는 요청을 '/api/users', '/api/auth'로 리다이렉트
-  app.use((req: Request, _res: Response, next: NextFunction) => {
-    const url = String(req.url ?? '');
-    if (/^\/(users|auth)(\/|$)/.test(url)) {
-      req.url = `/api${url}`;
-    }
-    next();
-  });
+  app.useGlobalFilters(new SentryGlobalFilter());
 
-  // 전역 파이프
   app.useGlobalPipes(
     new ValidationPipe({
       whitelist: true,
@@ -62,26 +72,23 @@ async function bootstrap() {
     }),
   );
 
-  // Swagger 설정
   const config = new DocumentBuilder()
-    .setTitle('Codi-it API Docs')
-    .setDescription('상품/주문/스토어 API 명세')
-    .setVersion('1.0')
+    .setTitle('CODI-IT')
+    .setDescription('CODI-IT API 명세입니다.')
+    .setVersion('1.0.0')
     .addBearerAuth()
     .build();
 
   const document = SwaggerModule.createDocument(app, config);
-  // 기존 '/api'에서 '/api/docs'로 분리 (API 라우트와 충돌 방지)
   SwaggerModule.setup('api/docs', app, document);
 
-  // 서버 실행
   const port = Number(process.env.PORT ?? 3000);
   await app.listen(port);
-  console.log(`🚀 Server running on http://localhost:${port}`);
-  console.log(`📘 Swagger docs available at http://localhost:${port}/api/docs`);
+  console.log(`Server running on http://localhost:${port}`);
+  console.log(`Swagger docs available at http://localhost:${port}/api/docs`);
 }
 
 bootstrap().catch((err) => {
-  console.error(`bootstrap failed: ${String(err)}`);
+  console.error('bootstrap failed: ', err);
   process.exit(1);
 });


### PR DESCRIPTION
## 📝 요약
- CORS 설정 로직을 환경변수를 기반으로 화이트리스트 구조로 수정했습니다.

## 📝 변경사항
- CORS 화이트리스트 로직의 가독성을 개선했습니다.
- 와일드카드(*.vercel.app)를 지원하는 코드를 추가했습니다.
- 기본적으로 허용할 로컬 주소는 명시적으로 작성했습니다 > http://localhost:3001

## 📝 추가설명
- .env의 CORS_ORIGINS 값만 수정해도 환경별 설정을 쉽게 변경할 수 있습니다.
-  프론트엔드의 라우팅 구조를 수정하는 것이 적절하다고 생각되어서  /users, /auth 요청을 /api 경로로 리다이렉트하던 미들웨어는 삭제했습니다.

## 🔗관련 이슈
- Closes #198 

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).