### PR TITLE
refactor:장바구니 api 리팩토링

### DIFF
--- a/src/cart/cart.controller.ts
+++ b/src/cart/cart.controller.ts
@@ -5,17 +5,17 @@ import {
   Patch,
   UseGuards,
   Req,
-  ForbiddenException,
   Get,
   Param,
   Delete,
   Logger,
 } from '@nestjs/common';
 import { CartService } from './cart.service';
-import { Cart, UserType, CartItem } from '@prisma/client';
+import { Cart, CartItem } from '@prisma/client';
 import { createOrUpdateCartItemsDto } from './cart.dto';
 import { AuthUser } from 'src/auth/auth.types';
 import { JwtAuthGuard } from 'src/auth/jwt.guard';
+import { BuyerGuard } from 'src/common/guard/buyer.guard';
 import { ApiOperation, ApiBody, ApiHeader, ApiResponse } from '@nestjs/swagger';
 @Controller('api/cart')
 export class CartController {
@@ -24,7 +24,7 @@ export class CartController {
   constructor(private cartService: CartService) {}
 
   //사용자의 장바구니를 생성합니다. 이미 존재하는 경우 해당 장바구니를 반환합니다.
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, BuyerGuard)
   @ApiOperation({ summary: '장바구니 생성' })
   @ApiHeader({
     name: 'Authorization',
@@ -46,15 +46,11 @@ export class CartController {
   @Post()
   async create(@Req() req: { user: AuthUser }): Promise<Cart> {
     const user = req.user;
-    if (user.type !== UserType.BUYER) {
-      this.logger.error('구매자만 접근 가능합니다');
-      throw new ForbiddenException('구매자만 접근 가능합니다');
-    }
     return this.cartService.createCart(user.userId);
   }
 
   //장바구니에서 특정 아이템의 상세 정보를 조회합니다.
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, BuyerGuard)
   @ApiOperation({ summary: '장바구니 아이템 조회' })
   @ApiHeader({
     name: 'Authorization',
@@ -83,7 +79,7 @@ export class CartController {
   }
 
   //사용자의 장바구니를 조회합니다. 장바구니가 없으면 빈 배열을 반환합니다.
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, BuyerGuard)
   @ApiOperation({ summary: '장바구니 조회' })
   @ApiHeader({
     name: 'Authorization',
@@ -101,16 +97,12 @@ export class CartController {
   @Get()
   async getCart(@Req() req: { user: AuthUser }) {
     const user = req.user;
-    if (user.type !== UserType.BUYER) {
-      this.logger.error('구매자만 접근 가능합니다');
-      throw new ForbiddenException('구매자만 접근 가능합니다');
-    }
     const cart = await this.cartService.getCart(user.userId);
     return cart;
   }
 
   //사용자의 장바구니를 업데이트합니다.
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, BuyerGuard)
   @ApiOperation({ summary: '장바구니 업데이트' })
   @ApiHeader({
     name: 'Authorization',
@@ -136,10 +128,6 @@ export class CartController {
     @Body() createOrUpdateCartItemsDto: createOrUpdateCartItemsDto,
   ): Promise<Cart> {
     const user = req.user;
-    if (user.type !== UserType.BUYER) {
-      this.logger.error('구매자만 접근 가능합니다');
-      throw new ForbiddenException('구매자만 접근 가능합니다');
-    }
     const updatedCart =
       await this.cartService.createOrUpdateCartItemAndReturnCart(
         user.userId,
@@ -148,7 +136,7 @@ export class CartController {
     return updatedCart;
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, BuyerGuard)
   @ApiOperation({ summary: '장바구니 아이템 삭제' })
   @ApiHeader({
     name: 'Authorization',
@@ -173,10 +161,6 @@ export class CartController {
     @Param('cartItemId') cartItemId: string,
   ) {
     const user = req.user;
-    if (user.type !== UserType.BUYER) {
-      this.logger.error('구매자만 접근 가능합니다');
-      throw new ForbiddenException('구매자만 접근 가능합니다');
-    }
     const deletedCartItem = await this.cartService.deleteCartItem(
       user.userId,
       cartItemId,

--- a/src/cart/cart.service.ts
+++ b/src/cart/cart.service.ts
@@ -7,24 +7,23 @@ import {
 import { CartRepository } from './cart.repository';
 import { createOrUpdateCartItemsDto } from './cart.dto';
 import { Logger } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
 @Injectable()
 export class CartService {
-  constructor(private cartRepository: CartRepository) {}
+  constructor(
+    private cartRepository: CartRepository,
+    private prisma: PrismaService,
+  ) {}
 
   private readonly logger = new Logger(CartService.name);
 
   // 사용자의 장바구니를 생성하거나 이미 존재하는 장바구니를 반환
   async createCart(buyerId: string) {
-    if (typeof buyerId !== 'string' || buyerId.trim() === '') {
-      this.logger.error('유효한 buyerId가 필요합니다');
-      throw new BadRequestException('유효한 buyerId가 필요합니다');
-    }
     const cart = await this.cartRepository.createOrGetCart(buyerId);
     if (!cart) {
       this.logger.error('장바구니 생성 실패');
       throw new BadRequestException('장바구니 생성 실패');
     }
-    this.logger.log('장바구니 생성 성공');
     return cart;
   }
 
@@ -34,7 +33,6 @@ export class CartService {
       this.logger.error(`장바구니 조회 실패 ${buyerId}`);
       return [];
     }
-    this.logger.log(`장바구니 조회 성공 ${buyerId}`);
     return cart;
   }
 
@@ -42,23 +40,68 @@ export class CartService {
     buyerId: string,
     createOrUpdateCartItemsDto: createOrUpdateCartItemsDto,
   ) {
-    const cart = await this.cartRepository.getCartIdByBuyerId(buyerId);
+    const cart = await this.cartRepository.getCartByBuyerId(buyerId);
     if (!cart) {
       this.logger.error('장바구니를 찾을 수 없습니다');
       throw new BadRequestException('장바구니를 찾을 수 없습니다');
     }
-    // 장바구니 업데이트
-    const updatedCart =
-      await this.cartRepository.createOrUpdateCartItemAndReturnCart(
+    return this.cartRepository.executeTransaction(async (tx) => {
+      // 상품 확인
+      const product = await this.prisma.product.findUnique({
+        where: {
+          id: createOrUpdateCartItemsDto.productId,
+        },
+      });
+      if (!product) {
+        this.logger.error('상품을 찾을 수 없습니다');
+        throw new BadRequestException('상품을 찾을 수 없습니다');
+      }
+      // 1. 장바구니 아이템 업데이트
+      for (const size of createOrUpdateCartItemsDto.sizes) {
+        // 상품의 사이즈 확인
+        const stockSize = await this.prisma.stockSize.findUnique({
+          where: {
+            id: size.sizeId,
+          },
+        });
+        if (!stockSize) {
+          this.logger.error('사이즈를 찾을 수 없습니다');
+          throw new BadRequestException('사이즈를 찾을 수 없습니다');
+        }
+        // 장바구니 아이템 업데이트
+        await this.cartRepository.upsertCartItem(
+          cart.id,
+          createOrUpdateCartItemsDto.productId,
+          size.sizeId,
+          size.quantity,
+          tx,
+        );
+      }
+
+      // 2. 장바구니 아이템 조회
+      const cartItems = await this.cartRepository.findCartWithItems(
         cart.id,
-        createOrUpdateCartItemsDto,
+        tx,
       );
-    if (!updatedCart) {
-      this.logger.error('장바구니 업데이트 실패');
-      throw new BadRequestException('장바구니 업데이트 실패');
-    }
-    this.logger.log('장바구니 업데이트 성공');
-    return updatedCart;
+      // 3. 장바구니의 총 수량 계산
+      const totalQuantityForCart = cartItems.items.reduce(
+        (total, item) => total + item.quantity,
+        0,
+      );
+      // 4. 장바구니의 총 수량 업데이트
+      await this.cartRepository.updateCartTotalQuantity(
+        cart.id,
+        totalQuantityForCart,
+        tx,
+      );
+
+      // 5. 최종 결과 반환
+      const updatedCart = await this.cartRepository.getCartByBuyerId(
+        buyerId,
+        tx,
+      );
+      return updatedCart!;
+    });
   }
 
   async getCartItem(userId: string, cartItemId: string) {
@@ -71,7 +114,6 @@ export class CartService {
       this.logger.error('장바구니 아이템 조회 권한이 없습니다');
       throw new ForbiddenException('장바구니 아이템 조회 권한이 없습니다');
     }
-    this.logger.log('장바구니 아이템 조회 성공');
     return cartItem;
   }
 
@@ -85,7 +127,6 @@ export class CartService {
       this.logger.error('장바구니 아이템 삭제 권한이 없습니다');
       throw new ForbiddenException('장바구니 아이템 삭제 권한이 없습니다');
     }
-    this.logger.log('장바구니 아이템 삭제 성공');
     return this.cartRepository.deleteCartItem(cartItemId);
   }
 }

--- a/src/cart/test/cart.e2e.spec.ts
+++ b/src/cart/test/cart.e2e.spec.ts
@@ -154,7 +154,6 @@ describe('장바구니 통합 테스트', () => {
         });
       expect(response.statusCode).toBe(200);
       const body = response.body as { items: { id: string }[] };
-      console.log(body, productId, sizeId);
       cartItemId = body.items[0].id;
     });
 

--- a/src/cart/test/cart.e2e.spec.ts
+++ b/src/cart/test/cart.e2e.spec.ts
@@ -154,6 +154,7 @@ describe('장바구니 통합 테스트', () => {
         });
       expect(response.statusCode).toBe(200);
       const body = response.body as { items: { id: string }[] };
+      console.log(body, productId, sizeId);
       cartItemId = body.items[0].id;
     });
 

--- a/src/common/guard/buyer.guard.ts
+++ b/src/common/guard/buyer.guard.ts
@@ -1,0 +1,22 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  ForbiddenException,
+} from '@nestjs/common';
+import { AuthUser } from 'src/auth/auth.types';
+import { UserType } from '@prisma/client';
+
+@Injectable()
+export class BuyerGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request: { user: AuthUser } = context.switchToHttp().getRequest();
+    const user = request.user;
+
+    if (!user || user.type !== UserType.BUYER) {
+      throw new ForbiddenException('구매자만 접근 가능합니다');
+    }
+
+    return true;
+  }
+}

--- a/src/common/guard/seller.guard.ts
+++ b/src/common/guard/seller.guard.ts
@@ -1,0 +1,22 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  ForbiddenException,
+} from '@nestjs/common';
+import { AuthUser } from 'src/auth/auth.types';
+import { UserType } from '@prisma/client';
+
+@Injectable()
+export class SellerGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request: { user: AuthUser } = context.switchToHttp().getRequest();
+    const user = request.user;
+
+    if (!user || user.type !== UserType.SELLER) {
+      throw new ForbiddenException('판매자만 접근 가능합니다');
+    }
+
+    return true;
+  }
+}


### PR DESCRIPTION
## 📝 요약
- cart.controller에서 유저 타입을 확인하는 로직을 제거하고 데코레이터로 변경
  - buyerGuard를 개발하여 컨트롤러에서 유저 타입을 확인
  - sellerGuard도 같이 추가
- cart.repository장바구니 수정 코드 수정
  - 기존 코드는 repository에 로직이 들어있어서 repository역활과 다른 로직이 있었음
- cart.service장바구니 수정 코드 수정
  - 기존 repository에서 있던 로직을 service로 옮겨옴
- 리팩토링에 따른 테스트 코드 수정 
<!--- ex) 내용 설명 -->


## 📝 추가설명
- service, repository 코드변경 설명
  - 기존 로직은 service에서 productid 와 sizes배열을 repository로 넘겨서 repository에서 모든 로직 처리
  - 수정된 로직은 service에서 데이터를 가공하여 repository에서는 prisma연결만 처리 
<!--- ex) 추가설명 -->


## 🔗관련 이슈
- Closes #179 

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).