### PR TITLE
feat: 프로필 이미지 S3 업로드 기능 추가

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,8 @@ import { ValidationPipe } from '@nestjs/common';
 import { setupSentry } from './common/logger/sentry.config';
 import { SentryGlobalFilter } from './common/logger/sentry.filter';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import * as express from 'express';
+import { resolve } from 'path';
 
 type Matcher = string | RegExp;
 
@@ -62,6 +64,11 @@ async function bootstrap() {
   });
 
   app.use(cookieParser());
+
+  const UPLOAD_DIR =
+    process.env.UPLOAD_DIR || resolve(process.cwd(), 'uploads');
+  app.use('/uploads', express.static(UPLOAD_DIR));
+  console.log('[uploads] serving from:', UPLOAD_DIR);
 
   app.useGlobalFilters(new SentryGlobalFilter());
 

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -3,9 +3,10 @@ import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 import { UsersRepository } from './users.repository';
 import { PrismaModule } from '../prisma/prisma.module';
+import { S3Module } from '../s3/s3.module';
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, S3Module],
   controllers: [UsersController],
   providers: [UsersService, UsersRepository],
   exports: [UsersService, UsersRepository],

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -7,14 +7,22 @@ import {
 import { UsersRepository } from './users.repository';
 import { CreateUserDto } from './dto/create-user.dto';
 import type { Prisma, User, UserType } from '@prisma/client';
-import { toUserPayload, UserPayload } from './users.mapper';
+import {
+  toUserPayload,
+  UserPayload,
+  toFavoriteStoreList,
+  FavoriteStoreItemDto,
+} from './users.mapper';
 import * as bcrypt from 'bcrypt';
 import { UpdateUserDto } from './dto/update-user.dto';
-import { toFavoriteStoreList, FavoriteStoreItemDto } from './users.mapper';
+import { S3Service } from '../s3/s3.service';
 
 @Injectable()
 export class UsersService {
-  constructor(private readonly usersRepo: UsersRepository) {}
+  constructor(
+    private readonly usersRepo: UsersRepository,
+    private readonly s3Service: S3Service,
+  ) {}
 
   async findById(id: string): Promise<User | null> {
     return this.usersRepo.findById(id);
@@ -23,7 +31,6 @@ export class UsersService {
   async create(dto: CreateUserDto): Promise<{ user: UserPayload }> {
     const email = dto.email.trim().toLowerCase();
 
-    // 이메일 중복 확인
     const exists = await this.usersRepo.existsByEmail(email);
     if (exists) {
       throw new ConflictException('이미 가입된 이메일입니다.');
@@ -49,7 +56,11 @@ export class UsersService {
     return toUserPayload(user);
   }
 
-  async updateMe(userId: string, dto: UpdateUserDto): Promise<UserPayload> {
+  async updateMe(
+    userId: string,
+    dto: UpdateUserDto,
+    image?: Express.Multer.File,
+  ): Promise<UserPayload> {
     const user = await this.usersRepo.findById(userId);
     if (!user) throw new NotFoundException('유저 정보를 찾을 수 없습니다.');
 
@@ -59,19 +70,29 @@ export class UsersService {
     }
 
     const data: Prisma.UserUpdateInput = {};
+
     if (dto.name) data.name = dto.name;
-    if (dto.image !== undefined) data.image = dto.image;
     if (dto.password) {
       data.passwordHash = await bcrypt.hash(dto.password, 10);
+    }
+
+    // 파일이 온 경우에만 S3 업로드 → URL 저장
+    if (image && image.buffer && image.mimetype?.startsWith('image/')) {
+      const { url } = await this.s3Service.uploadFile(image);
+      data.image = url;
+    } else if (dto.image !== undefined) {
+      data.image = dto.image;
     }
 
     const updated = await this.usersRepo.updateById(userId, data);
     return toUserPayload(updated);
   }
+
   async getMyLikes(userId: string): Promise<FavoriteStoreItemDto[]> {
     const rows = await this.usersRepo.findLikesByUserId(userId);
     return toFavoriteStoreList(rows);
   }
+
   async deleteMe(userId: string): Promise<void> {
     const user = await this.usersRepo.findById(userId);
     if (!user) throw new NotFoundException('유저를 찾을 수 없습니다.');


### PR DESCRIPTION
## 📝 요약
<!--- ex) 내용 설명 -->
- 프로필 이미지 S3 업로드 기능 추가

## 📝 변경사항
<!--- ex) 변경사항 -->
- UsersService에 S3Service 주입 및 업로드 로직 추가
- users.module.ts에 S3Module import
- S3 업로드 후 URL을 DB에 저장하도록 수정

## 📝 추가설명
<!--- ex) 추가설명 -->
- S3 URL이 정상적으로 반환 및 표시됨
<img width="795" height="930" alt="스크린샷 2025-10-23 161124" src="https://github.com/user-attachments/assets/89500b45-c307-4349-90ac-134c49734369" />
<img width="1102" height="407" alt="스크린샷 2025-10-23 161004" src="https://github.com/user-attachments/assets/69f269e6-7312-4ace-938d-c6277cf5907c" />

## 🔗관련 이슈
- Closes #208 

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).