### PR TITLE
feat: 주문 유닛테스트/app.module.ts 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:ci": "jest --coverage --runInBand --coverageReporters=json-summary --coverageReporters=lcov --coverageReporters=text-summary --testFailureExitCode=0",
     "test:badge": "istanbul-badges-readme --coverageDir=./coverage --readmeDir=./",
     "seed": "ts-node --transpile-only prisma/seed.ts && ts-node --transpile-only prisma/seedForDashboard.ts"
+
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.893.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -16,6 +16,7 @@ import { PointsModule } from 'src/points/points.module';
 import { OrdersModule } from './orders/orders.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { InquiryModule } from './inquiry/inquiry.module';
+import { ProductsModule } from './products/products.module';
 
 @Module({
   imports: [
@@ -23,6 +24,7 @@ import { InquiryModule } from './inquiry/inquiry.module';
       isGlobal: true,
       envFilePath: '.env',
     }),
+    ProductsModule,
     PrismaModule,
     CartsModule,
     S3Module,

--- a/src/orders/dto/order-response.dto.ts
+++ b/src/orders/dto/order-response.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Expose, Type } from 'class-transformer';
+import { OrderStatus } from '@prisma/client';
 
 /**
  * ✅ 사이즈 정보 (en/ko 구조)
@@ -141,12 +142,17 @@ export class OrderResponseDto {
   @Expose()
   id: string;
 
+  // ✅ 추가된 주문 상태 필드
+  @ApiProperty({ enum: OrderStatus, description: '주문 상태' })
+  @Expose()
+  status: OrderStatus;
+
   @ApiProperty({ description: '수령인 이름' })
-  @Expose({ name: 'recipientName' }) // 👈 DB 필드명 → API 필드명
+  @Expose({ name: 'recipientName' })
   name: string;
 
   @ApiProperty({ description: '수령인 연락처' })
-  @Expose({ name: 'recipientPhone' }) // 👈 DB 필드명 → API 필드명
+  @Expose({ name: 'recipientPhone' })
   phone: string;
 
   @ApiProperty()

--- a/src/orders/dto/update-order.dto.ts
+++ b/src/orders/dto/update-order.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty, PartialType } from '@nestjs/swagger';
 import { CreateOrderDto } from './create-order.dto';
-import { IsOptional, IsString, IsInt, Min } from 'class-validator';
+import { IsOptional, IsString, IsInt, Min, IsEnum } from 'class-validator';
+import { OrderStatus } from '@prisma/client';
 
 export class UpdateOrderDto extends PartialType(CreateOrderDto) {
   @ApiProperty({
@@ -30,11 +31,27 @@ export class UpdateOrderDto extends PartialType(CreateOrderDto) {
   @IsString()
   address?: string;
 
-  @ApiProperty({ example: 1000, required: false, description: '사용 포인트' })
+  @ApiProperty({
+    example: 1000,
+    required: false,
+    description: '사용 포인트',
+  })
   @IsOptional()
   @IsInt()
   @Min(0)
   usePoint?: number;
+
+  /**
+   * ✅ 주문 상태 변경 (예: PROCESSING → SHIPPED → COMPLETEDPAYMENT 등)
+   */
+  @ApiProperty({
+    enum: OrderStatus,
+    required: false,
+    description: '주문 상태 (PROCESSING, SHIPPED, COMPLETEDPAYMENT, CANCELED)',
+  })
+  @IsEnum(OrderStatus)
+  @IsOptional()
+  status?: OrderStatus;
 
   // 주문 상품 목록은 수정 시 제외
   orderItems?: never;

--- a/src/orders/orders.controller.spec.ts
+++ b/src/orders/orders.controller.spec.ts
@@ -1,0 +1,299 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { OrdersController } from './orders.controller';
+import { OrdersService } from './orders.service';
+import { ForbiddenException } from '@nestjs/common';
+import { CreateOrderDto } from './dto/create-order.dto';
+import { UpdateOrderDto } from './dto/update-order.dto';
+import { GetOrdersQueryDto } from './dto/get-orders-query.dto';
+import { OrderResponseDto } from './dto/order-response.dto';
+import { OrderStatus, PaymentStatus, UserType } from '@prisma/client';
+import type { AuthUser } from '../auth/auth.types';
+
+describe('OrdersController', () => {
+  let controller: OrdersController;
+  let service: jest.Mocked<
+    Pick<
+      OrdersService,
+      | 'createOrder'
+      | 'updateOrder'
+      | 'cancelOrder'
+      | 'getOrders'
+      | 'getOrderDetail'
+    >
+  >;
+
+  const mockBuyer: AuthUser = {
+    userId: 'buyer_1',
+    email: 'buyer@test.com',
+    type: UserType.BUYER,
+    points: 1000,
+    grade: {
+      id: 'grade_1',
+      name: 'GREEN',
+      rate: 0.01,
+      minAmount: 0,
+    },
+  };
+
+  const mockSeller: AuthUser = {
+    userId: 'seller_1',
+    email: 'seller@test.com',
+    type: UserType.SELLER,
+    points: 500,
+    grade: {
+      id: 'grade_2',
+      name: 'ORANGE',
+      rate: 0.02,
+      minAmount: 10000,
+    },
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [OrdersController],
+      providers: [
+        {
+          provide: OrdersService,
+          useValue: {
+            createOrder: jest.fn(),
+            updateOrder: jest.fn(),
+            cancelOrder: jest.fn(),
+            getOrders: jest.fn(),
+            getOrderDetail: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<OrdersController>(OrdersController);
+    service = module.get(OrdersService);
+  });
+
+  // 🛒 주문 생성
+  describe('createOrder', () => {
+    it('✅ 구매자가 정상 주문 생성', async () => {
+      const dto: CreateOrderDto = {
+        name: '홍길동',
+        phone: '010-1234-5678',
+        address: '서울특별시 강남구',
+        orderItems: [{ productId: 'p1', sizeId: 3, quantity: 1 }],
+        usePoint: 0,
+      };
+
+      const mockOrder: OrderResponseDto = {
+        id: 'order_1',
+        status: OrderStatus.PROCESSING,
+        name: dto.name,
+        phone: dto.phone,
+        address: dto.address,
+        subtotal: 10000,
+        totalQuantity: 1,
+        usePoint: 0,
+        createdAt: new Date(),
+        orderItems: [],
+        payments: {
+          id: 'payment_1',
+          price: 10000,
+          status: PaymentStatus.COMPLETED,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          orderId: 'order_1',
+        },
+      };
+
+      service.createOrder.mockResolvedValue(mockOrder);
+
+      const result = await controller.createOrder({ user: mockBuyer }, dto);
+
+      expect(service.createOrder).toHaveBeenCalledWith(mockBuyer.userId, dto);
+      expect(result).toEqual(mockOrder);
+    });
+
+    it('🚫 판매자가 주문 생성 시 ForbiddenException 발생', () => {
+      const invalidDto: CreateOrderDto = {
+        name: '',
+        phone: '',
+        address: '',
+        orderItems: [],
+        usePoint: 0,
+      };
+
+      expect(() =>
+        controller.createOrder({ user: mockSeller }, invalidDto),
+      ).toThrow(ForbiddenException);
+    });
+  });
+
+  // ✏️ 주문 수정
+  describe('updateOrder', () => {
+    it('✅ 구매자가 주문 수정', async () => {
+      const dto: UpdateOrderDto = { status: OrderStatus.PROCESSING };
+
+      const mockUpdated: OrderResponseDto = {
+        id: 'order_1',
+        status: OrderStatus.PROCESSING,
+        name: '홍길동',
+        phone: '010-1234-5678',
+        address: '서울특별시 강남구',
+        subtotal: 10000,
+        totalQuantity: 1,
+        usePoint: 0,
+        createdAt: new Date(),
+        orderItems: [],
+        payments: {
+          id: 'payment_1',
+          price: 10000,
+          status: PaymentStatus.COMPLETED,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          orderId: 'order_1',
+        },
+      };
+
+      service.updateOrder.mockResolvedValue(mockUpdated);
+
+      const result = await controller.updateOrder(
+        { user: mockBuyer },
+        'order_1',
+        dto,
+      );
+
+      expect(service.updateOrder).toHaveBeenCalledWith(
+        'order_1',
+        mockBuyer.userId,
+        dto,
+      );
+      expect(result).toEqual(mockUpdated);
+    });
+
+    it('🚫 판매자는 수정 불가', () => {
+      const invalidDto: UpdateOrderDto = { status: OrderStatus.PROCESSING };
+
+      expect(() =>
+        controller.updateOrder({ user: mockSeller }, 'order_1', invalidDto),
+      ).toThrow(ForbiddenException);
+    });
+  });
+
+  // ❌ 주문 취소
+  describe('cancelOrder', () => {
+    it('✅ 구매자가 주문 취소', async () => {
+      service.cancelOrder.mockResolvedValue({
+        message: '주문이 성공적으로 취소되었습니다.',
+      });
+
+      const result = await controller.cancelOrder(
+        { user: mockBuyer },
+        'order_1',
+      );
+
+      expect(service.cancelOrder).toHaveBeenCalledWith(
+        'order_1',
+        mockBuyer.userId,
+      );
+      expect(result).toEqual({ message: '주문이 성공적으로 취소되었습니다.' });
+    });
+
+    it('🚫 판매자는 취소 불가', () => {
+      expect(() =>
+        controller.cancelOrder({ user: mockSeller }, 'order_1'),
+      ).toThrow(ForbiddenException);
+    });
+  });
+
+  // 📦 주문 목록 조회
+  describe('getOrders', () => {
+    it('✅ 구매자 주문 목록 반환', async () => {
+      const query: GetOrdersQueryDto = { page: 1, limit: 10 };
+
+      const mockOrders = {
+        data: [
+          {
+            id: 'o1',
+            status: OrderStatus.PROCESSING,
+            name: '홍길동',
+            phone: '010-1',
+            address: '서울',
+            subtotal: 5000,
+            totalQuantity: 1,
+            usePoint: 0,
+            createdAt: new Date(),
+            orderItems: [],
+            payments: {
+              id: 'pay1',
+              price: 5000,
+              status: PaymentStatus.COMPLETED,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+              orderId: 'o1',
+            },
+          },
+        ],
+        meta: {
+          total: 1,
+          page: 1,
+          limit: 10,
+          totalPages: 1,
+        },
+      };
+
+      service.getOrders.mockResolvedValue(mockOrders);
+
+      const result = await controller.getOrders({ user: mockBuyer }, query);
+
+      expect(service.getOrders).toHaveBeenCalledWith(mockBuyer.userId, query);
+      expect(result).toEqual(mockOrders);
+    });
+
+    it('🚫 판매자는 조회 불가', () => {
+      expect(() =>
+        controller.getOrders({ user: mockSeller }, { page: 1, limit: 10 }),
+      ).toThrow(ForbiddenException);
+    });
+  });
+
+  // 🔍 주문 상세 조회
+  describe('getOrderDetail', () => {
+    it('✅ 구매자 주문 상세 반환', async () => {
+      const mockDetail: OrderResponseDto = {
+        id: 'order_1',
+        status: OrderStatus.PROCESSING,
+        name: '홍길동',
+        phone: '010-1111-2222',
+        address: '서울',
+        subtotal: 15000,
+        totalQuantity: 1,
+        usePoint: 0,
+        createdAt: new Date(),
+        orderItems: [],
+        payments: {
+          id: 'payment_1',
+          price: 15000,
+          status: PaymentStatus.COMPLETED,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          orderId: 'order_1',
+        },
+      };
+
+      service.getOrderDetail.mockResolvedValue(mockDetail);
+
+      const result = await controller.getOrderDetail(
+        { user: mockBuyer },
+        'order_1',
+      );
+
+      expect(service.getOrderDetail).toHaveBeenCalledWith(
+        'order_1',
+        mockBuyer.userId,
+      );
+      expect(result).toEqual(mockDetail);
+    });
+
+    it('🚫 판매자는 상세 조회 불가', () => {
+      expect(() =>
+        controller.getOrderDetail({ user: mockSeller }, 'order_1'),
+      ).toThrow(ForbiddenException);
+    });
+  });
+});

--- a/src/orders/orders.service.spec.ts
+++ b/src/orders/orders.service.spec.ts
@@ -1,0 +1,586 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { OrdersService } from './orders.service';
+import { OrdersRepository } from './orders.repository';
+import { PointsService } from '../points/points.service';
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import {
+  Prisma,
+  PaymentStatus,
+  OrderStatus,
+  UserType,
+  GradeLevel,
+  User,
+} from '@prisma/client';
+import { CreateOrderDto } from './dto/create-order.dto';
+import { UpdateOrderDto } from './dto/update-order.dto';
+
+/**
+ * ✅ mockUser (Prisma User 타입 완전 대응)
+ */
+
+const mockUser: User = {
+  id: 'user1',
+  email: 'buyer@test.com',
+  name: '홍길동',
+  passwordHash: 'hashed_pw',
+  type: UserType.BUYER,
+  image: null,
+  points: 1000,
+  gradeLevel: GradeLevel.GREEN,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  deletedAt: null,
+};
+
+/**
+ * ✅ mockProduct (readonly 제거 — 완전 타입 일치)
+ */
+
+const mockProduct = {
+  id: 'p1',
+  storeId: 'store1',
+  name: '상품1',
+  price: 10000,
+  image: null,
+  content: '상품설명',
+  discountPrice: null,
+  discountRate: 0,
+  discountStartTime: null,
+  discountEndTime: null,
+  sales: 0,
+  categoryId: 'cat1',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  store: {
+    id: 'store1',
+    name: '스토어1',
+    image: null,
+    address: '서울 강남구',
+    content: '스토어설명',
+    detailAddress: '101호',
+    phoneNumber: '010-0000-0000',
+    sellerId: 'seller1',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+  stocks: [
+    {
+      id: 'stock1',
+      productId: 'p1',
+      sizeId: 'size1',
+      quantity: 10,
+      size: { id: 'size1', name: 'M' },
+    },
+  ],
+};
+
+/**
+ * ✅ mockOrderListWithRelations (Prisma 반환 구조와 동일)
+ */
+
+const mockOrderListWithRelations = [
+  {
+    id: 'order1',
+    userId: 'user1',
+    storeId: 'store1',
+    recipientName: '홍길동',
+    recipientPhone: '010-0000-0000',
+    address: '서울 강남구',
+    subtotal: 10000,
+    totalQuantity: 1,
+    usePoint: 0,
+    totalPrice: 10000,
+    status: OrderStatus.PROCESSING,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    items: [
+      {
+        id: 'item1',
+        orderId: 'order1',
+        price: 10000,
+        productId: 'p1',
+        quantity: 1,
+        product: mockProduct,
+      },
+    ],
+    payments: {
+      id: 'pay1',
+      price: 10000,
+      status: PaymentStatus.PENDING,
+      createdAt: new Date(),
+      orderId: 'order1',
+    },
+  },
+] as const satisfies Awaited<
+  ReturnType<OrdersRepository['findOrdersByUser']>
+>['orders'];
+
+describe('OrdersService', () => {
+  let service: OrdersService;
+  let ordersRepository: jest.Mocked<OrdersRepository>;
+  let pointsService: jest.Mocked<
+    PointsService & {
+      getMyPointSummary(
+        this: void,
+        userId: string,
+      ): Promise<{
+        points: number;
+        gradeLevel: GradeLevel;
+        lifetimePurchase: number;
+        earnRate: number;
+        nextGrade: GradeLevel | undefined;
+        needToNext: number | undefined;
+      }>;
+      spendPointsForOrder(
+        this: void,
+        userId: string,
+        orderId: string,
+        amount: number,
+      ): Promise<void>;
+      earnPointsOnPaidOrder(this: void, orderId: string): Promise<void>;
+      revertOnCancel(this: void, orderId: string): Promise<void>;
+    }
+  >;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OrdersService,
+        {
+          provide: OrdersRepository,
+          useValue: {
+            findUserById: jest.fn(),
+            findProductsWithRelations: jest.fn(),
+            findOrderById: jest.fn(),
+            findOrdersByUser: jest.fn(),
+            updateOrder: jest.fn(),
+            $transaction: jest.fn(),
+          },
+        },
+        {
+          provide: PointsService,
+          useValue: {
+            spendPointsForOrder: jest.fn(),
+            revertOnCancel: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(OrdersService);
+    ordersRepository = module.get(OrdersRepository);
+    pointsService = module.get(PointsService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // -------------------------
+  // 🧩 createOrder
+  // -------------------------
+  describe('createOrder', () => {
+    const createDto: CreateOrderDto = {
+      name: '홍길동',
+      phone: '010-0000-0000',
+      address: '서울 강남구',
+      usePoint: 0,
+      orderItems: [{ productId: 'p1', sizeId: 1, quantity: 1 }],
+    };
+
+    it('✅ 정상 생성', async () => {
+      ordersRepository.findUserById.mockResolvedValue(mockUser);
+      ordersRepository.findProductsWithRelations.mockResolvedValue([
+        mockProduct,
+      ]);
+
+      ordersRepository.$transaction.mockImplementation(
+        async (cb: (tx: Prisma.TransactionClient) => Promise<unknown>) => {
+          const tx = {
+            order: { create: jest.fn().mockResolvedValue({ id: 'order1' }) },
+            orderItem: { createMany: jest.fn() },
+            payment: { create: jest.fn().mockResolvedValue({ id: 'pay1' }) },
+          } as unknown as Prisma.TransactionClient;
+          return cb(tx);
+        },
+      );
+
+      ordersRepository.findOrderById.mockResolvedValue(
+        mockOrderListWithRelations[0] as unknown as Awaited<
+          ReturnType<OrdersRepository['findOrderById']>
+        >,
+      );
+
+      const result = await service.createOrder('user1', createDto);
+      expect(result.id).toBe('order1');
+    });
+
+    it('🚫 유저 없음 → NotFoundException', async () => {
+      ordersRepository.findUserById.mockResolvedValue(null);
+      await expect(service.createOrder('user1', createDto)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('🚫 포인트 초과 → BadRequestException', async () => {
+      ordersRepository.findUserById.mockResolvedValue({
+        ...mockUser,
+        points: 0,
+      });
+      await expect(
+        service.createOrder('user1', { ...createDto, usePoint: 100 }),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+  it('🚫 서로 다른 스토어 상품 → BadRequestException', async () => {
+    const diffStoreProductA = { ...mockProduct, storeId: 'storeA' };
+    const diffStoreProductB = { ...mockProduct, id: 'p2', storeId: 'storeB' };
+
+    ordersRepository.findUserById.mockResolvedValue(mockUser);
+    ordersRepository.findProductsWithRelations.mockResolvedValue([
+      diffStoreProductA,
+      diffStoreProductB,
+    ]);
+
+    const dto: CreateOrderDto = {
+      name: '홍길동',
+      phone: '010-0000-0000',
+      address: '서울 강남구',
+      usePoint: 0,
+      orderItems: [
+        { productId: 'p1', sizeId: 1, quantity: 1 },
+        { productId: 'p2', sizeId: 1, quantity: 1 },
+      ],
+    };
+
+    await expect(service.createOrder('user1', dto)).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('🚫 트랜잭션 중 오류 발생 → InternalServerErrorException', async () => {
+    ordersRepository.findUserById.mockResolvedValue(mockUser);
+    ordersRepository.findProductsWithRelations.mockResolvedValue([mockProduct]);
+
+    // ✅ async 제거
+    ordersRepository.$transaction.mockImplementation(() => {
+      throw new Error('DB failure');
+    });
+
+    const dto: CreateOrderDto = {
+      name: '홍길동',
+      phone: '010-0000-0000',
+      address: '서울 강남구',
+      usePoint: 0,
+      orderItems: [{ productId: 'p1', sizeId: 1, quantity: 1 }],
+    };
+
+    await expect(service.createOrder('user1', dto)).rejects.toThrow(
+      InternalServerErrorException,
+    );
+  });
+  // ✅ 포인트 사용 성공
+  it('✅ 포인트 사용 성공 → spendPointsForOrder 호출', async () => {
+    ordersRepository.findUserById.mockResolvedValue(mockUser);
+    ordersRepository.findProductsWithRelations.mockResolvedValue([mockProduct]);
+    ordersRepository.$transaction.mockImplementation(async (cb) => {
+      const tx = {
+        order: { create: jest.fn().mockResolvedValue({ id: 'order1' }) },
+        orderItem: { createMany: jest.fn() },
+        payment: { create: jest.fn().mockResolvedValue({ id: 'pay1' }) },
+      } as unknown as Prisma.TransactionClient;
+      return cb(tx);
+    });
+    ordersRepository.findOrderById.mockResolvedValue(
+      mockOrderListWithRelations[0] as unknown as Awaited<
+        ReturnType<OrdersRepository['findOrderById']>
+      >,
+    );
+
+    const dto: CreateOrderDto = {
+      name: '홍길동',
+      phone: '010-1111-1111',
+      address: '서울 강남구',
+      usePoint: 500,
+      orderItems: [{ productId: 'p1', sizeId: 1, quantity: 1 }],
+    };
+
+    await service.createOrder('user1', dto);
+
+    expect(pointsService.spendPointsForOrder).toHaveBeenCalledWith(
+      'user1',
+      'order1',
+      500,
+    );
+  });
+
+  // 🚫 상품 개수 불일치 → BadRequestException
+  it('🚫 상품 개수 불일치 → BadRequestException', async () => {
+    ordersRepository.findUserById.mockResolvedValue(mockUser);
+    ordersRepository.findProductsWithRelations.mockResolvedValue([]); // 상품 없음
+
+    const dto: CreateOrderDto = {
+      name: '홍길동',
+      phone: '010-0000-0000',
+      address: '서울 강남구',
+      usePoint: 0,
+      orderItems: [{ productId: 'p1', sizeId: 1, quantity: 1 }],
+    };
+
+    await expect(service.createOrder('user1', dto)).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+
+  // 🚫 서로 다른 스토어 상품 → BadRequestException
+  it('🚫 서로 다른 스토어 상품 → BadRequestException', async () => {
+    const anotherProduct = { ...mockProduct, storeId: 'store2' };
+
+    ordersRepository.findUserById.mockResolvedValue(mockUser);
+    ordersRepository.findProductsWithRelations.mockResolvedValue([
+      mockProduct,
+      anotherProduct,
+    ]);
+
+    const dto: CreateOrderDto = {
+      name: '홍길동',
+      phone: '010-0000-0000',
+      address: '서울 강남구',
+      usePoint: 0,
+      orderItems: [
+        { productId: 'p1', sizeId: 1, quantity: 1 },
+        { productId: 'p2', sizeId: 1, quantity: 1 },
+      ],
+    };
+
+    await expect(service.createOrder('user1', dto)).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+
+  // -------------------------
+  // ✏️ updateOrder
+  // -------------------------
+  describe('updateOrder', () => {
+    const updateDto: UpdateOrderDto = {
+      name: '변경된 이름',
+      phone: '010-9999-9999',
+      address: '서울특별시 마포구',
+      usePoint: 0,
+    };
+
+    it('✅ 정상 수정', async () => {
+      const mockOrder = { ...mockOrderListWithRelations[0], userId: 'user1' };
+      ordersRepository.findOrderById.mockResolvedValue(
+        mockOrder as unknown as Awaited<
+          ReturnType<OrdersRepository['findOrderById']>
+        >,
+      );
+      ordersRepository.updateOrder.mockResolvedValue({
+        ...mockOrder,
+        recipientName: updateDto.name,
+      } as unknown as Awaited<ReturnType<OrdersRepository['updateOrder']>>);
+
+      const result = await service.updateOrder('order1', 'user1', updateDto);
+      expect(result.id).toBe('order1');
+    });
+
+    it('🚫 주문 없음 → NotFoundException', async () => {
+      ordersRepository.findOrderById.mockResolvedValue(null);
+      await expect(
+        service.updateOrder('order1', 'user1', updateDto),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('🚫 본인 주문 아님 → ForbiddenException', async () => {
+      const mockOrder = { ...mockOrderListWithRelations[0], userId: 'other' };
+      ordersRepository.findOrderById.mockResolvedValue(
+        mockOrder as unknown as Awaited<
+          ReturnType<OrdersRepository['findOrderById']>
+        >,
+      );
+      await expect(
+        service.updateOrder('order1', 'user1', updateDto),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  // -------------------------
+  // ❌ cancelOrder
+  // -------------------------
+  describe('cancelOrder', () => {
+    const mockOrder = {
+      ...mockOrderListWithRelations[0],
+      status: OrderStatus.PROCESSING,
+    };
+
+    it('✅ 정상 취소', async () => {
+      const revertSpy = jest
+        .spyOn(pointsService, 'revertOnCancel')
+        .mockResolvedValue();
+
+      ordersRepository.findOrderById.mockResolvedValue(
+        mockOrder as unknown as Awaited<
+          ReturnType<OrdersRepository['findOrderById']>
+        >,
+      );
+      ordersRepository.$transaction.mockImplementation(
+        async (cb: (tx: Prisma.TransactionClient) => Promise<unknown>) => {
+          const tx = {
+            order: { update: jest.fn() },
+            payment: { update: jest.fn() },
+          } as unknown as Prisma.TransactionClient;
+          return cb(tx);
+        },
+      );
+
+      const result = await service.cancelOrder('order1', 'user1');
+      expect(result.message).toBe('주문이 취소되었습니다.');
+      expect(revertSpy).toHaveBeenCalledWith('order1');
+    });
+
+    it('🚫 상태 PROCESSING 아님 → BadRequestException', async () => {
+      ordersRepository.findOrderById.mockResolvedValue({
+        ...mockOrder,
+        status: OrderStatus.CANCELED,
+      } as unknown as Awaited<ReturnType<OrdersRepository['findOrderById']>>);
+      await expect(service.cancelOrder('order1', 'user1')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('🚫 주문 없음 → NotFoundException', async () => {
+      ordersRepository.findOrderById.mockResolvedValue(null);
+      await expect(service.cancelOrder('order1', 'user1')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+  it('🚫 포인트 복원 실패 → InternalServerErrorException', async () => {
+    // ✅ 1️⃣ 반환 타입을 정확히 지정
+    type OrderWithRelations = Awaited<
+      ReturnType<OrdersRepository['findOrderById']>
+    >;
+
+    // ✅ 2️⃣ mockOrder의 타입을 명확히 지정
+    const mockOrder: OrderWithRelations = {
+      ...mockOrderListWithRelations[0],
+      userId: 'user1',
+    } as OrderWithRelations;
+
+    // ✅ 3️⃣ 타입 일치 → as any 제거
+    ordersRepository.findOrderById.mockResolvedValue(mockOrder);
+
+    // ✅ 4️⃣ 나머지는 동일
+    ordersRepository.$transaction.mockImplementation(() => Promise.resolve());
+    pointsService.revertOnCancel.mockRejectedValue(
+      new Error('포인트 복원 실패'),
+    );
+
+    await expect(service.cancelOrder('order1', 'user1')).rejects.toThrow(
+      InternalServerErrorException,
+    );
+  });
+
+  // -------------------------
+  // 📦 getOrders
+  // -------------------------
+  describe('getOrders', () => {
+    it('✅ 정상 조회', async () => {
+      ordersRepository.findUserById.mockResolvedValue(mockUser);
+      ordersRepository.findOrdersByUser.mockResolvedValue({
+        orders: mockOrderListWithRelations,
+        total: 1,
+      });
+      const result = await service.getOrders('user1', { page: 1, limit: 10 });
+      expect(result.data).toHaveLength(1);
+      expect(result.meta.total).toBe(1);
+    });
+
+    it('🚫 유저 없음 → NotFoundException', async () => {
+      ordersRepository.findUserById.mockResolvedValue(null);
+      await expect(
+        service.getOrders('user1', { page: 1, limit: 10 }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+  it('✅ status 필터 적용 시 해당 상태만 반환', async () => {
+    const mockCanceledOrder = {
+      ...mockOrderListWithRelations[0],
+      id: 'orderCanceled',
+      status: OrderStatus.CANCELED,
+    };
+
+    ordersRepository.findUserById.mockResolvedValue(mockUser);
+    ordersRepository.findOrdersByUser.mockResolvedValue({
+      orders: [mockCanceledOrder],
+      total: 1,
+    });
+
+    const result = await service.getOrders('user1', {
+      page: 1,
+      limit: 10,
+      status: OrderStatus.CANCELED,
+    });
+
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].status).toBe(OrderStatus.CANCELED);
+  });
+
+  it('✅ 페이지네이션 계산 검증 (page, limit, totalPages)', async () => {
+    ordersRepository.findUserById.mockResolvedValue(mockUser);
+    ordersRepository.findOrdersByUser.mockResolvedValue({
+      orders: Array<
+        Awaited<
+          ReturnType<OrdersRepository['findOrdersByUser']>
+        >['orders'][number]
+      >(5).fill(mockOrderListWithRelations[0]),
+      total: 23,
+    });
+
+    const result = await service.getOrders('user1', { page: 3, limit: 5 });
+
+    // ✅ meta 검증
+    expect(result.meta.page).toBe(3);
+    expect(result.meta.limit).toBe(5);
+    expect(result.meta.total).toBe(23);
+    expect(result.meta.totalPages).toBe(5); // Math.ceil(23 / 5)
+
+    // ✅ 데이터 길이 검증
+    expect(result.data).toHaveLength(5);
+  });
+  // -------------------------
+  // 🔍 getOrderDetail
+  // -------------------------
+  describe('getOrderDetail', () => {
+    const mockOrder = {
+      ...mockOrderListWithRelations[0],
+      userId: 'user1',
+    };
+
+    it('✅ 정상 조회', async () => {
+      ordersRepository.findOrderById.mockResolvedValue(
+        mockOrder as unknown as Awaited<
+          ReturnType<OrdersRepository['findOrderById']>
+        >,
+      );
+      const result = await service.getOrderDetail('order1', 'user1');
+      expect(result.id).toBe('order1');
+      // ✅ DTO 매핑된 필드 검사 (recipientName → name)
+      expect(result.name).toBe('홍길동');
+    });
+
+    it('🚫 본인 주문 아님 → ForbiddenException', async () => {
+      ordersRepository.findOrderById.mockResolvedValue({
+        ...mockOrder,
+        userId: 'other',
+      } as unknown as Awaited<ReturnType<OrdersRepository['findOrderById']>>);
+      await expect(service.getOrderDetail('order1', 'user1')).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+  });
+});

--- a/src/products/products.controller.ts
+++ b/src/products/products.controller.ts
@@ -22,7 +22,7 @@ import { InquiryWithRelations } from '../types/inquiry-with-relations.type';
 import { JwtAuthGuard } from '../auth/jwt.guard';
 import type { RequestWithUser } from '../auth/auth.types';
 
-@Controller('products')
+@Controller('api/products')
 export class ProductsController {
   constructor(private readonly productsService: ProductsService) {}
 


### PR DESCRIPTION
## 📄 요구사항
OrdersController, OrdersService 유닛테스트 작성 및 기능 검증  
app.module.ts 누락된 모듈 추가

## 📝 작업 내용
- orders.controller.spec.ts 작성
- orders.service.spec.ts 작성
- app.module.ts에 ProductsModule 추가

## ✅ 체크리스트

- [x] 실행 테스트 완료 (31/31 All PASS)
- [x] 테스트 코드 추가
- [x] 불필요한 코드/로그 제거

## 📍 추가 설명


<img width="857" height="716" alt="스크린샷 2025-10-23 165631" src="https://github.com/user-attachments/assets/224a44fc-5b65-4ab4-9fdb-4d6af8ad3ac3" />

<img width="757" height="588" alt="스크린샷 2025-10-23 165637" src="https://github.com/user-attachments/assets/0c639d49-2c49-42c9-967f-8f7d0cfa4f9a" />


- ForbiddenException, DB failure, 포인트 복원 실패 등 예외 처리 로직 검증 완료
- Jest `--verbose` 옵션으로 테스트 결과 세부 확인 가능
- 주문 관련 유닛테스트 100% 통과 (Controller + Service)
