### PR TITLE
fix: 스토어 등록 생성 로직 수정

### DIFF
--- a/src/s3/s3.controller.ts
+++ b/src/s3/s3.controller.ts
@@ -43,7 +43,7 @@ export class S3Controller {
     description: '이미지 업로드 실패',
   })
   @UseInterceptors(
-    FileInterceptor('file', {
+    FileInterceptor('image', {
       fileFilter: imageFileFilter,
       limits: {
         fileSize: 1024 * 1024 * 10, // 파일 크기 제한 10MB

--- a/src/store/dto/create-store-form.dto.ts
+++ b/src/store/dto/create-store-form.dto.ts
@@ -1,0 +1,25 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateStoreFormDto {
+  @ApiProperty({ description: '스토어명' })
+  storeName: string;
+
+  @ApiProperty({ description: '기본 주소', name: 'address.basic' })
+  'address.basic': string;
+
+  @ApiProperty({ description: '상세 주소(선택)', name: 'address.detail' })
+  'address.detail'?: string;
+
+  @ApiProperty({ description: '전화번호' })
+  phoneNumber: string;
+
+  @ApiProperty({ description: '스토어 설명' })
+  description: string;
+
+  @ApiProperty({
+    type: 'string',
+    format: 'binary',
+    description: '대표 이미지 파일(선택)',
+  })
+  image?: any;
+}

--- a/src/store/dto/create-store-response.dto.ts
+++ b/src/store/dto/create-store-response.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class CreateStoreResponseDto {
+  @ApiProperty() id: string;
+  @ApiProperty() storeName: string;
+  @ApiProperty() phoneNumber: string;
+  @ApiProperty() description: string;
+  @ApiPropertyOptional() address: { basic: string; detail?: string };
+  @ApiProperty() image?: string;
+  @ApiProperty() createdAt: Date;
+  @ApiProperty() updatedAt: Date;
+}

--- a/src/store/dto/create-store.dto.ts
+++ b/src/store/dto/create-store.dto.ts
@@ -3,7 +3,7 @@ import { IsString, IsNotEmpty, IsOptional } from 'class-validator';
 export class CreateStoreDto {
   @IsString() @IsNotEmpty() name: string;
   @IsString() @IsNotEmpty() address: string;
-  @IsString() @IsNotEmpty() detailAddress: string;
+  @IsOptional() @IsString() detailAddress?: string;
   @IsString() @IsNotEmpty() phoneNumber: string;
   @IsString() @IsNotEmpty() content: string;
   @IsOptional() @IsString() image?: string;

--- a/src/store/store.controller.spec.ts
+++ b/src/store/store.controller.spec.ts
@@ -1,12 +1,15 @@
+// store.controller.spec.ts
 import { Test, TestingModule } from '@nestjs/testing';
 import { StoreController } from './store.controller';
 import { StoreService } from './store.service';
+import { S3Service } from '../s3/s3.service';
 import type { AuthUser } from '../auth/auth.types';
 import { UserType } from '@prisma/client';
 
 describe('StoreController', () => {
   let controller: StoreController;
   let service: jest.Mocked<StoreService>;
+  let s3: jest.Mocked<S3Service>;
 
   const mockService: jest.Mocked<StoreService> = {
     createStore: jest.fn(),
@@ -18,6 +21,10 @@ describe('StoreController', () => {
     deleteInterestStore: jest.fn(),
   } as any;
 
+  const mockS3: jest.Mocked<S3Service> = {
+    uploadFile: jest.fn(),
+  } as any;
+
   const req = (over?: Partial<AuthUser>) => ({
     user: { userId: 'u1', type: UserType.SELLER, ...(over ?? {}) } as AuthUser,
   });
@@ -25,35 +32,111 @@ describe('StoreController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [StoreController],
-      providers: [{ provide: StoreService, useValue: mockService }],
+      providers: [
+        { provide: StoreService, useValue: mockService },
+        { provide: S3Service, useValue: mockS3 },
+      ],
     }).compile();
 
     controller = module.get(StoreController);
     service = module.get(StoreService) as any;
+    s3 = module.get(S3Service) as any;
+
     jest.clearAllMocks();
   });
 
-  it('스토어 등록', async () => {
-    service.createStore.mockResolvedValue({ id: 's1' } as any);
+  describe('스토어 등록', () => {
     const dto = {
       name: 'New Store',
       address: '서울특별시 용산구',
       detailAddress: '서빙고로 137',
       phoneNumber: '02-0000-0000',
       content: '트렌디한 백자를 판매합니다.',
+    };
+
+    const createdStore = {
+      id: 's1',
+      name: 'New Store',
+      address: '서울특별시 용산구',
+      detailAddress: '서빙고로 137',
+      phoneNumber: '02-0000-0000',
+      content: '트렌디한 백자를 판매합니다.',
+      image: 'https://bucket.s3.ap-northeast-2.amazonaws.com/upload/x.jpg',
+      createdAt: new Date('2025-10-28T01:23:45.000Z'),
+      updatedAt: new Date('2025-10-28T01:23:45.000Z'),
     } as any;
-    const result = await controller.create(req(), dto);
-    expect(service.createStore).toHaveBeenCalledWith(
-      'u1',
-      UserType.SELLER,
-      dto,
-    );
-    expect(result).toEqual({ id: 's1' });
+
+    it('파일 없이 생성', async () => {
+      service.createStore.mockResolvedValue({ ...createdStore, image: null });
+
+      const res = await controller.create(req(), undefined, { ...dto });
+
+      expect(s3.uploadFile).not.toHaveBeenCalled();
+      expect(service.createStore).toHaveBeenCalledWith('u1', UserType.SELLER, {
+        ...dto,
+        image: undefined,
+      });
+
+      expect(res).toEqual({
+        id: createdStore.id,
+        storeName: createdStore.name,
+        phoneNumber: createdStore.phoneNumber,
+        description: createdStore.content,
+        address: {
+          basic: createdStore.address,
+          detail: createdStore.detailAddress,
+        },
+        image: undefined,
+        createdAt: createdStore.createdAt,
+        updatedAt: createdStore.updatedAt,
+      });
+    });
+
+    it('파일 포함 생성, S3 업로드 URL이 DTO.image에 반영', async () => {
+      const file = {
+        originalname: 'a.jpg',
+        mimetype: 'image/jpeg',
+        size: 1234,
+        buffer: Buffer.from('x'),
+      } as Express.Multer.File;
+
+      s3.uploadFile.mockResolvedValue({
+        message: '업로드 성공',
+        url: createdStore.image,
+        key: 'upload/x.jpg',
+      });
+
+      service.createStore.mockResolvedValue(createdStore);
+
+      const res = await controller.create(req(), file, { ...dto });
+
+      expect(s3.uploadFile).toHaveBeenCalledWith(file);
+      expect(service.createStore).toHaveBeenCalledWith('u1', UserType.SELLER, {
+        ...dto,
+        image: createdStore.image,
+      });
+
+      expect(res).toEqual({
+        id: createdStore.id,
+        storeName: createdStore.name,
+        phoneNumber: createdStore.phoneNumber,
+        description: createdStore.content,
+        address: {
+          basic: createdStore.address,
+          detail: createdStore.detailAddress,
+        },
+        image: createdStore.image,
+        createdAt: createdStore.createdAt,
+        updatedAt: createdStore.updatedAt,
+      });
+    });
   });
 
   it('내 스토어 상세 조회', async () => {
     service.getMyStoreDetail.mockResolvedValue({ id: 's1' } as any);
-    await controller.getMyStoreDetail(req());
+    await controller.getMyStoreDetail({
+      user: { userId: 'u1', type: UserType.SELLER } as AuthUser,
+    });
     expect(service.getMyStoreDetail).toHaveBeenCalledWith(
       'u1',
       UserType.SELLER,
@@ -63,7 +146,10 @@ describe('StoreController', () => {
   it('스토어에 등록된 상품 목록 조회', async () => {
     service.getMyStoreProducts.mockResolvedValue({ list: [], totalCount: 0 });
     const query = { page: 2, pageSize: 5 } as any;
-    await controller.getMyStoreProducts(req(), query);
+    await controller.getMyStoreProducts(
+      { user: { userId: 'u1', type: UserType.SELLER } as AuthUser },
+      query,
+    );
     expect(service.getMyStoreProducts).toHaveBeenCalledWith(
       'u1',
       UserType.SELLER,
@@ -97,7 +183,9 @@ describe('StoreController', () => {
     service.registerInterestStore.mockResolvedValue({
       store: { id: 's1' } as any,
     });
-    await controller.registerInterestStore('s1', req());
+    await controller.registerInterestStore('s1', {
+      user: { userId: 'u1', type: UserType.SELLER } as AuthUser,
+    });
     expect(service.registerInterestStore).toHaveBeenCalledWith('s1', 'u1');
   });
 
@@ -105,7 +193,9 @@ describe('StoreController', () => {
     service.deleteInterestStore.mockResolvedValue({
       store: { id: 's1' } as any,
     });
-    await controller.deleteInterestStore('s1', req());
+    await controller.deleteInterestStore('s1', {
+      user: { userId: 'u1', type: UserType.SELLER } as AuthUser,
+    });
     expect(service.deleteInterestStore).toHaveBeenCalledWith('s1', 'u1');
   });
 });

--- a/src/store/store.module.ts
+++ b/src/store/store.module.ts
@@ -3,10 +3,12 @@ import { StoreService } from './store.service';
 import { StoreController } from './store.controller';
 import { StoreRepository } from './store.repository';
 import { PrismaModule } from '../prisma/prisma.module';
+import { ConfigModule } from '@nestjs/config';
+import { S3Service } from 'src/s3/s3.service';
 
 @Module({
-  imports: [PrismaModule],
-  providers: [StoreService, StoreRepository],
+  imports: [PrismaModule, ConfigModule],
+  providers: [StoreService, StoreRepository, S3Service],
   controllers: [StoreController],
 })
 export class StoreModule {}


### PR DESCRIPTION
## 📝 요약
- 스토어 생성 API를 수정했습니다. 
- FE의 FormData를 그대로 받아서 S3에 업로드하고, 반환 URL을 DB에 저장한 뒤 FE 가 기대하는 응답 형태로 매핑했습니다.

## 📝 변경사항
1. DTO
- reateStoreDto를 FE FormData 필드와 1:1로 정리 : name, address, detailAddress?, phoneNumber, content, image?
- 생성 응답용 CreateStoreResponseDto 사용
2. Controller
- POST /api/stores에서 @ApiConsumes('multipart/form-data') 적용
- FileInterceptor('image', { limits: 10MB }) 적용, imageFileFilter 재사용
- 업로드 파일 존재 시 S3Service.uploadFile 호출하고, URL을 dto.image에 주입
- 응답을 CreateStoreResponseDto로 매핑
3. Service
- createStore에서 이미지 URL 포함하여 Prisma.StoreCreateInput 구성
- detailAddress는 FE에서 생략 가능하기 때문에 ' '로 저장
4. S3 연동
- 컨트롤러에서 S3 업로드 호출 후 URL 저장 흐름으로 통합

## 📝 추가설명
- FE에서 사용하고 있는 필드명에 맞게 BE도 image로 필드명을 변경했습니다.
- Prisma 스키마 변경없이 detailAddress는 미입력 시 빈 문자열로 저장되게 작성했습니다.

## 🔗관련 이슈
- Closes #218 

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).