### PR TITLE
fix: findInquiries 메서드 반환 값에 총 개수 데이터 및 트랜잭션 처리 추가, 반환 형식 수정, 비밀글 처리 방식 수정

### DIFF
--- a/src/products/products.controller.ts
+++ b/src/products/products.controller.ts
@@ -18,14 +18,17 @@ import { UpdateProductDto } from './dto/update-product.dto';
 import { FindProductsQueryDto } from './dto/find-products-query.dto';
 import { CreateInquiryDto } from './dto/create-inquiry.dto';
 import { Product, Inquiry } from '@prisma/client';
-import { InquiryWithRelations } from '../types/inquiry-with-relations.type';
 import { JwtAuthGuard } from '../auth/jwt.guard';
 import type { RequestWithUser } from '../auth/auth.types';
-import type { productResponse, ProductListResponse } from './products.service';
+import type {
+  ProductResponse,
+  ProductListResponse,
+  InquiryResponse,
+} from './products.service';
 
 @Controller('api/products')
 export class ProductsController {
-  constructor(private readonly productsService: ProductsService) {}
+  constructor(private readonly productsService: ProductsService) { }
 
   /** 상품 등록 */
   @Post()
@@ -47,7 +50,7 @@ export class ProductsController {
 
   /** 상품 상세 조회 (비로그인 가능) */
   @Get(':id')
-  async findOne(@Param('id') id: string): Promise<productResponse> {
+  async findOne(@Param('id') id: string): Promise<ProductResponse> {
     return this.productsService.findOne(id);
   }
 
@@ -90,7 +93,7 @@ export class ProductsController {
   async findInquiries(
     @Param('id') productId: string,
     @Req() req: RequestWithUser,
-  ): Promise<InquiryWithRelations[]> {
+  ): Promise<InquiryResponse> {
     return this.productsService.findInquiries(productId, req.user.userId);
   }
 }


### PR DESCRIPTION
## 📝 요약
Swagger에 작성된 반환 형식과 FE 코드에 요구된 반환 형식 동기화 작업

## 📝 변경사항
- 문의 목록 조회 레포에 트랜잭션 및 totalCount 조회 로직 추가
- 문의 목록 조회 반환 타입 수정
- 문의 목록 조회 시 비밀글 예외처리 방식 수정
 
## 📝 추가설명
프론트엔드 예시 페이지에서 `비밀글 접근 권한이 없는 경우` 아래와 같이 반환하는 것으로 확인하여 적용하였습니다
```
{
     "id": "CUID",
      "userId": "CUID",
      "productId": "CUID",
      "title": "비밀 문의",
      "content": "비밀 내용입니다.",
      "status": "CompletedAnswer",
      "isSecret": true,
      "createdAt": "2023-10-01T00:00:00.000Z",
      "updatedAt": "2023-10-01T00:00:00.000Z",
      "user": {
        "name": "김유저"
      },
      "reply": null
    }
```

## 🔗관련 이슈
- Closes #233 

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).