### PR TITLE
chore: 무중단 배포 위한 스크립트 수정

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -120,32 +120,102 @@ jobs:
             docker pull "$IMAGE:latest"
             docker run --rm --env-file "$ENV_FILE" "$IMAGE:latest" npx prisma migrate deploy
 
-      # 컨테이너 배포
-      - name: Deploy new container on EC2
+      # Blue, Green
+      - name: Deploy Blue, Green on EC2
         uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.PRIVATE_KEY }}
           script: |
-            set -e
-            IMAGE="${{ secrets.DOCKER_USERNAME }}/${{ secrets.IMAGE_NAME }}"
-            CONTAINER_NAME="${{ secrets.CONTAINER_NAME }}"
-            ENV_FILE=~/apps/NB02_CODI-IT_BE/.env
+            set -euo pipefail
 
+            IMAGE="${{ secrets.DOCKER_USERNAME }}/${{ secrets.IMAGE_NAME }}"
+            APP_DIR="$HOME/apps/NB02_CODI-IT_BE"
+            ENV_FILE="$APP_DIR/.env"
+            CONTAINER_BASENAME="${{ secrets.CONTAINER_NAME }}"
             [ -z "$CONTAINER_NAME" ] && CONTAINER_NAME="codiit-backend"
 
-            echo "Deploying $IMAGE as $CONTAINER_NAME (bind 127.0.0.1:3000)"
+            BLUE_PORT=3001
+            GREEN_PORT=3002
 
+            ACTIVE_LINK="/etc/nginx/conf.d/upstreams/active.conf"
+            BLUE_CONF="/etc/nginx/conf.d/upstreams/blue.conf"
+            GREEN_CONF="/etc/nginx/conf.d/upstreams/green.conf"
+
+            echo "Check .env"
+            test -f "$ENV_FILE" || (echo "ERROR: $ENV_FILE not found"; exit 1)
+            grep -qE '^DATABASE_URL=' "$ENV_FILE" || (echo "ERROR: DATABASE_URL missing"; exit 1)
+
+            echo "Docker login & pull"
+            echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
             docker pull "$IMAGE:latest"
-            docker stop "$CONTAINER_NAME" || true
-            docker rm "$CONTAINER_NAME" || true
+
+            ACTIVE_COLOR="blue"
+            if [ -L "$ACTIVE_LINK" ]; then
+              TARGET=$(readlink "$ACTIVE_LINK" || true)
+              case "$TARGET" in
+                *green.conf) ACTIVE_COLOR="green" ;;
+                *blue.conf)  ACTIVE_COLOR="blue" ;;
+              esac
+            fi
+
+            if [ "$ACTIVE_COLOR" = "blue" ]; then
+              IDLE_COLOR="green"; IDLE_PORT=$GREEN_PORT
+              ACTIVE_PORT=$BLUE_PORT
+            else
+              IDLE_COLOR="blue"; IDLE_PORT=$BLUE_PORT
+              ACTIVE_PORT=$GREEN_PORT
+            fi
+
+            ACTIVE_NAME="${CONTAINER_BASENAME}-${ACTIVE_COLOR}"
+            IDLE_NAME="${CONTAINER_BASENAME}-${IDLE_COLOR}"
+
+            echo "Active=$ACTIVE_COLOR($ACTIVE_PORT), Idle=$IDLE_COLOR($IDLE_PORT)"
+
+            echo "Run idle container"
+            docker stop "$IDLE_NAME" || true
+            docker rm   "$IDLE_NAME" || true
+
 
             docker run -d \
-              --name "$CONTAINER_NAME" \
+              --name "$IDLE_NAME" \
               --restart unless-stopped \
               --env-file "$ENV_FILE" \
-              -p 127.0.0.1:3000:3000 \
+              -p 127.0.0.1:${IDLE_PORT}:3000 \
               "$IMAGE:latest"
 
-            docker image prune -f
+            echo "Health check idle"
+            HEALTH_PATH="${{ secrets.HEALTHCHECK_PATH }}"
+            [ -z "${HEALTH_PATH:-}" ] && HEALTH_PATH="/health"
+
+            for i in $(seq 1 30); do
+              if curl -fsS "http://127.0.0.1:${IDLE_PORT}${HEALTH_PATH}" >/dev/null 2>&1; then
+                echo "Health OK"
+                break
+              fi
+              echo "Waiting health... ($i)"
+              sleep 1
+              if [ $i -eq 30 ]; then
+                echo "ERROR: Health check failed"
+                docker logs "$IDLE_NAME" || true
+                exit 1
+              fi
+            done
+
+            echo "Switch Nginx to $IDLE_COLOR"
+            if [ "$IDLE_COLOR" = "blue" ]; then
+              sudo ln -sf "$BLUE_CONF" "$ACTIVE_LINK"
+            else
+              sudo ln -sf "$GREEN_CONF" "$ACTIVE_LINK"
+            fi
+
+            sudo nginx -t
+            sudo nginx -s reload
+
+            echo "Stop old active"
+            docker stop "$ACTIVE_NAME" || true
+            docker rm   "$ACTIVE_NAME" || true
+
+            echo "Prune images"
+            docker image prune -f || true

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -17,6 +17,7 @@ import { OrdersModule } from './orders/orders.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { InquiryModule } from './inquiry/inquiry.module';
 import { ProductsModule } from './products/products.module';
+import { HealthModule } from './health/health.module';
 
 @Module({
   imports: [
@@ -39,6 +40,7 @@ import { ProductsModule } from './products/products.module';
     NotificationsModule,
     InquiryModule,
     ProductsModule,
+    HealthModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/health/health.controller.spec.ts
+++ b/src/health/health.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HealthController } from './health.controller';
+
+describe('HealthController', () => {
+  let controller: HealthController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [HealthController],
+    }).compile();
+
+    controller = module.get<HealthController>(HealthController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller('health')
+export class HealthController {
+  @Get()
+  ping() {
+    return { status: 'ok', timestamp: new Date().toISOString() };
+  }
+}

--- a/src/health/health.module.ts
+++ b/src/health/health.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { HealthController } from './health.controller';
+
+@Module({
+  controllers: [HealthController],
+})
+export class HealthModule {}


### PR DESCRIPTION
## 📝 요약
- 무중단 배포(Blue-Green Deploy)를 위한 CI/CD 파이프라인과 Nginx 설정을 수정했습니다.

## 📝 변경사항
1. GitHub Actions 워크플로우(ci-cd.yml) 내 배포 단계 수정
- 기존 단일 컨테이너 재시작 방식을 Blue, Green 무중단 배포 방식으로 교체
- 배포 시 헬스체크(/health) 통과 후 Nginx 업스트림 전환
- 비활성 컨테이너 자동 정리, 이미지 prune 추가
2. Nginx 설정 변경
- backend.conf 구조를 include /upstreams/active.conf 형태로 변경
- /etc/nginx/conf.d/upstreams/{blue.conf, green.conf, active.conf} 생성
- active.conf 심볼릭 링크를 통해 트래픽 전환 가능하도록 설정
3. EC2 내부 디렉토리 구조 정리, .env 자동 업로드 유지

## 📝 추가설명
- 현재 Nginx는 blue(3001) <-> green(3002) 두 포트를 번갈아 바라보며 무중단 배포를 수행합니다.
- 헬스체크 엔드포인트가 200 OK일 경우에만 전환되기 때문에 배포 중 다운타임이 없습니다.
- 경고는 기본 서버블록 정리 후 해결 예정입니다. 

## 🔗관련 이슈
- Closes #232 

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).