### PR TITLE
fix: 스토어 수정 API 전체 로직 및 DTO 구조 개선

### DIFF
--- a/src/store/dto/update-store-form.dto.ts
+++ b/src/store/dto/update-store-form.dto.ts
@@ -1,0 +1,42 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, IsBooleanString } from 'class-validator';
+
+export class UpdateStoreFormDto {
+  @ApiPropertyOptional({ description: '스토어명' })
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @ApiPropertyOptional({ description: '기본 주소', name: 'address.basic' })
+  @IsOptional()
+  @IsString()
+  address?: string;
+
+  @ApiPropertyOptional({
+    description: '상세 주소(선택)',
+    name: 'address.detail',
+  })
+  @IsOptional()
+  @IsString()
+  detailAddress?: string;
+
+  @ApiPropertyOptional({ description: '전화번호' })
+  @IsOptional()
+  @IsString()
+  phoneNumber?: string;
+
+  @ApiPropertyOptional({ description: '스토어 설명' })
+  @IsOptional()
+  @IsString()
+  content?: string;
+
+  @ApiPropertyOptional({ description: '대표 이미지 파일(선택)' })
+  @IsOptional()
+  @IsString()
+  image?: string;
+
+  @ApiPropertyOptional({ description: '이미지 제거' })
+  @IsOptional()
+  @IsBooleanString()
+  removeImage?: string;
+}

--- a/src/store/dto/update-store.dto.ts
+++ b/src/store/dto/update-store.dto.ts
@@ -1,10 +1,10 @@
 import { IsString, IsOptional } from 'class-validator';
 
 export class UpdateStoreDto {
-  @IsString() @IsOptional() name: string;
-  @IsString() @IsOptional() address: string;
-  @IsString() @IsOptional() detailAddress: string;
-  @IsString() @IsOptional() phoneNumber: string;
-  @IsString() @IsOptional() content: string;
-  @IsString() @IsOptional() image?: string | null;
+  @IsString() @IsOptional() name?: string;
+  @IsString() @IsOptional() address?: string;
+  @IsString() @IsOptional() detailAddress?: string;
+  @IsString() @IsOptional() phoneNumber?: string;
+  @IsString() @IsOptional() content?: string;
+  @IsOptional() image?: string | null;
 }


### PR DESCRIPTION
## 📝 요약
- 스토어 수정 API 전체 로직과 DTO 구조를 개선했습니다.
- 프론트엔드에서 전송하는 multipart/form-data 요청이 정상적으로 처리되도록 수정했습니다.

## 📝 변경사항
- UpdateStoreFormDto에 address, detailAddress 등 평탄 키 필드 추가
- 컨트롤러에서 평탄 키 우선적으로 매핑
- multipart/form-data 기반 파일 업로드 및 이미지 교체, 유지, 삭제 로직 개선
- removeImage 플래그 처리 추가 : true 시 이미지 제거

## 📝 추가설명
- 프론트와 백엔드의 필드 네이밍을 통일하여 모든 필드가 정상적으로 DB에 반영됩니다. 
- 프론트와 백엔드의 연동 테스트를 통해서 이름, 주소, 전화번호, 내용, 이미지 모두 정상적으로 수정되는 것을 확인했습니다.

## 🔗관련 이슈
- Closes #228 

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## ✅ 테스트 결과
<img width="831" height="194" alt="스크린샷 2025-10-29 오전 10 09 06" src="https://github.com/user-attachments/assets/5ede43bc-325e-4a0e-aa9b-8ac229ad8398" />
