### PR TITLE
chore: .env에 정의된 CORS_ORIGINS 값을 정상적으로 인식하도록 수정

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,19 +1,103 @@
 import cookieParser from 'cookie-parser';
+import * as express from 'express';
+import { resolve } from 'path';
+
 import { AppModule } from './app.module';
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
 import { setupSentry } from './common/logger/sentry.config';
 import { SentryGlobalFilter } from './common/logger/sentry.filter';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
-import * as express from 'express';
-import { resolve } from 'path';
 
-const ALLOW_ORIGINS = [
-  'https://nb-02-codi-it-fe.vercel.app',
-  'https://codi-it.shop',
-  'http://localhost:3001',
-  'http://localhost:3000',
-];
+// 콤마 구분 환경변수 파서
+function parseCommaSeparatedEnv(keys: string[]): string[] {
+  for (const envKey of keys) {
+    const envValue = process.env[envKey];
+    if (!envValue) continue;
+    return envValue
+      .split(',')
+      .map((item) => item.trim().replace(/^['"]|['"]$/g, ''))
+      .filter(Boolean);
+  }
+  return [];
+}
+
+// 스킴 보정, 슬래시 제거, 도메인 판별
+function normalizeOrigin(origin: string): string {
+  let formatted = origin.trim();
+  if (!formatted) return '';
+  formatted = formatted.replace(/\/+$/, '');
+
+  const hasScheme = /^https?:\/\//i.test(formatted);
+  const isLocalhost =
+    /^localhost(:\d+)?$/i.test(formatted) ||
+    /^http:\/\/localhost(:\d+)?$/i.test(formatted);
+  const isDomainPattern = /^[a-z0-9.-]+\.[a-z]{2,}$/i.test(formatted);
+
+  if (!hasScheme) {
+    if (isLocalhost) return `http://${formatted}`;
+    if (isDomainPattern) return `https://${formatted}`;
+  }
+  return formatted;
+}
+
+// dev/prod 분기, 중복 제거, 기본 로컬 허용
+function resolveAllowedOrigins(): string[] {
+  const isProduction = process.env.NODE_ENV === 'production';
+  const rawOriginList = parseCommaSeparatedEnv(
+    isProduction
+      ? ['CORS_ORIGINS_PROD', 'CORS_ORIGINS']
+      : ['CORS_ORIGINS_DEV', 'CORS_ORIGINS'],
+  );
+
+  const normalizedOrigins = rawOriginList.map(normalizeOrigin).filter(Boolean);
+  if (normalizedOrigins.length === 0) {
+    normalizedOrigins.push('http://localhost:3000', 'http://localhost:3001');
+  }
+  return Array.from(new Set(normalizedOrigins));
+}
+
+// cors origin 검증 콜백
+function createCorsOriginValidator() {
+  const allowedOrigins = resolveAllowedOrigins();
+  const isVercelWildcardEnabled =
+    String(process.env.CORS_ALLOW_VERCEL_WILDCARD ?? '').toLowerCase() ===
+    'true';
+  const isDebug =
+    process.env.CORS_DEBUG === 'true' || process.env.NODE_ENV !== 'production';
+
+  return (
+    requestOrigin: string | undefined,
+    callback: (err: Error | null, allow?: boolean) => void,
+  ) => {
+    if (!requestOrigin) return callback(null, true); // 서버-서버 호출, curl 등
+
+    const isExactMatch = allowedOrigins.includes(requestOrigin);
+
+    let isVercelPreviewAllowed = false;
+    if (isVercelWildcardEnabled) {
+      try {
+        const hostname = new URL(requestOrigin).hostname;
+        isVercelPreviewAllowed = /\.vercel\.app$/i.test(hostname);
+      } catch (e) {
+        if (isDebug) {
+          console.warn(
+            `[CORS] Invalid origin string (URL parse failed): "${requestOrigin}"`,
+            String(e),
+          );
+        }
+      }
+    }
+
+    const allowed = isExactMatch || isVercelPreviewAllowed;
+    if (isDebug && !allowed) {
+      console.warn(
+        `[CORS] Denied origin: ${requestOrigin} (allowed: ${JSON.stringify(allowedOrigins)})`,
+      );
+    }
+    callback(null, allowed);
+  };
+}
 
 async function bootstrap() {
   setupSentry();
@@ -22,11 +106,9 @@ async function bootstrap() {
     logger: ['log', 'error', 'warn', 'debug', 'verbose'],
   });
 
+  // cors
   app.enableCors({
-    origin(origin, cb) {
-      if (!origin) return cb(null, true); // curl/서버간 호출 허용
-      cb(null, ALLOW_ORIGINS.includes(origin));
-    },
+    origin: createCorsOriginValidator(),
     credentials: true,
     methods: ['GET', 'HEAD', 'PUT', 'PATCH', 'POST', 'DELETE', 'OPTIONS'],
     allowedHeaders: ['Content-Type', 'Authorization', 'X-Requested-With'],
@@ -35,13 +117,16 @@ async function bootstrap() {
 
   app.use(cookieParser());
 
+  // 업로드 정적 서빙
   const UPLOAD_DIR =
     process.env.UPLOAD_DIR || resolve(process.cwd(), 'uploads');
   app.use('/uploads', express.static(UPLOAD_DIR));
   console.log('[uploads] serving from:', UPLOAD_DIR);
 
+  // Sentry 글로벌 필터
   app.useGlobalFilters(new SentryGlobalFilter());
 
+  // 전역 파이프
   app.useGlobalPipes(
     new ValidationPipe({
       whitelist: true,
@@ -49,20 +134,21 @@ async function bootstrap() {
     }),
   );
 
-  const config = new DocumentBuilder()
+  // Swagger
+  const swaggerConfig = new DocumentBuilder()
     .setTitle('CODI-IT')
     .setDescription('CODI-IT API 명세입니다.')
     .setVersion('1.0.0')
     .addBearerAuth()
     .build();
-
-  const document = SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('api/docs', app, document);
+  const swaggerDocument = SwaggerModule.createDocument(app, swaggerConfig);
+  SwaggerModule.setup('api/docs', app, swaggerDocument);
 
   const port = Number(process.env.PORT ?? 3000);
   await app.listen(port);
   console.log(`Server running on http://localhost:${port}`);
   console.log(`Swagger docs available at http://localhost:${port}/api/docs`);
+  console.log('Allowed Origins:', resolveAllowedOrigins());
 }
 
 bootstrap().catch((err) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,6 @@
 import cookieParser from 'cookie-parser';
 import * as express from 'express';
 import { resolve } from 'path';
-
 import { AppModule } from './app.module';
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
@@ -70,7 +69,7 @@ function createCorsOriginValidator() {
     requestOrigin: string | undefined,
     callback: (err: Error | null, allow?: boolean) => void,
   ) => {
-    if (!requestOrigin) return callback(null, true); // 서버-서버 호출, curl 등
+    if (!requestOrigin) return callback(null, true);
 
     const isExactMatch = allowedOrigins.includes(requestOrigin);
 
@@ -117,16 +116,13 @@ async function bootstrap() {
 
   app.use(cookieParser());
 
-  // 업로드 정적 서빙
   const UPLOAD_DIR =
     process.env.UPLOAD_DIR || resolve(process.cwd(), 'uploads');
   app.use('/uploads', express.static(UPLOAD_DIR));
   console.log('[uploads] serving from:', UPLOAD_DIR);
 
-  // Sentry 글로벌 필터
   app.useGlobalFilters(new SentryGlobalFilter());
 
-  // 전역 파이프
   app.useGlobalPipes(
     new ValidationPipe({
       whitelist: true,
@@ -134,7 +130,6 @@ async function bootstrap() {
     }),
   );
 
-  // Swagger
   const swaggerConfig = new DocumentBuilder()
     .setTitle('CODI-IT')
     .setDescription('CODI-IT API 명세입니다.')


### PR DESCRIPTION
## 📝 요약
- main.ts의 CORS 설정 로직을 .env에 정의된 CORS_ORIGINS 값을 정상적으로 인식하도록 수정했습니다.
- 환경별로 CORS 허용 Origin을 관리하고, 스킴 자동 보정과 Vercel 프리뷰 도메인 허용 옵션을 추가했습니다.

## 📝 변경사항
- CORS 환경변수 기반 설정 추가
  - CORS_ORIGINS_DEV, CORS_ORIGINS_PROD, 
  - CORS_ALLOW_VERCEL_WILDCARD, CORS_DEBUG 환경변수 적용
  - Origin 자동 정규화(스킴과슬래시 보정, 중복 제거)
  - 비허용 Origin 디버그 로그 출력(CORS_DEBUG=true 시)

## 📝 추가설명
- 스킴이 생략된 Origin은 자동 보정됩니다.

## 🔗관련 이슈
- Closes #261 

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
<img width="689" height="85" alt="스크린샷 2025-10-30 오후 1 42 35" src="https://github.com/user-attachments/assets/8133c332-83aa-4f21-a04b-142154ff5906" />
