### PR TITLE
fix: Body 용량 제한 상향 (5MB) 설정

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import { ValidationPipe } from '@nestjs/common';
 import { setupSentry } from './common/logger/sentry.config';
 import { SentryGlobalFilter } from './common/logger/sentry.filter';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { json, urlencoded } from 'express';
 
 // 콤마 구분 환경변수 파서
 function parseCommaSeparatedEnv(keys: string[]): string[] {
@@ -115,6 +116,8 @@ async function bootstrap() {
   });
 
   app.use(cookieParser());
+  app.use(json({ limit: '5mb' }));
+  app.use(urlencoded({ limit: '5mb', extended: true }));
 
   const UPLOAD_DIR =
     process.env.UPLOAD_DIR || resolve(process.cwd(), 'uploads');


### PR DESCRIPTION
## 📝 요약
<!--- ex) 내용 설명 -->
- 요청 Body 용량 제한을 5MB로 상향하여 사용자 정보 수정 시 발생하던 413(Content Too Large) 오류 해결

## 📝 변경사항
<!--- ex) 변경사항 -->
- main.ts에 json 및 urlencoded 요청 크기 제한 5MB 설정 추가

## 📝 추가설명
<!--- ex) 추가설명 -->


## 🔗관련 이슈
- Closes #275 

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).